### PR TITLE
Add test cases for EIP-7623

### DIFF
--- a/eth/transaction/eth_transaction_rpc.py
+++ b/eth/transaction/eth_transaction_rpc.py
@@ -1354,6 +1354,19 @@ class TestEthNamespaceTransactionRPC(unittest.TestCase):
         _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
 
+    def test_eth_estimateGas_success_floor_data_gas(self):
+        method = f"{self.ns}_estimateGas"
+        address = test_data_set["account"]["sender"]["address"]
+        contract = test_data_set["contracts"]["unknown"]["address"][0]
+        large_calldata = test_data_set["contracts"]["unknown"]["input"] + "ff" * 1000  # Function call + 1KB of data
+        params = [{"from": address, "to": contract, "data": large_calldata}]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        self.assertIsNotNone(result)
+        estimated_gas = int(result, 16)
+        expected_gas = 61510
+        self.assertEqual(estimated_gas, expected_gas)
+
     def test_eth_estimateComputationCost_success(self):
         method = f"{self.ns}_estimateComputationCost"
         address = test_data_set["account"]["sender"]["address"]
@@ -1535,6 +1548,7 @@ class TestEthNamespaceTransactionRPC(unittest.TestCase):
         suite.addTest(TestEthNamespaceTransactionRPC("test_eth_estimateGas_error_evm_revert_message"))
         suite.addTest(TestEthNamespaceTransactionRPC("test_eth_estimateGas_error_revert"))
         suite.addTest(TestEthNamespaceTransactionRPC("test_eth_estimateGas_success"))
+        suite.addTest(TestEthNamespaceTransactionRPC("test_eth_estimateGas_success_floor_data_gas"))
         suite.addTest(TestEthNamespaceTransactionRPC("test_eth_getTransactionByHash_error_no_param"))
         suite.addTest(TestEthNamespaceTransactionRPC("test_eth_getTransactionByHash_error_wrong_type_param"))
         suite.addTest(TestEthNamespaceTransactionRPC("test_eth_getTransactionByHash_success_wrong_value_param"))

--- a/eth/transaction/eth_transaction_ws.py
+++ b/eth/transaction/eth_transaction_ws.py
@@ -1354,6 +1354,19 @@ class TestEthNamespaceTransactionWS(unittest.TestCase):
         _, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
 
+    def test_eth_estimateGas_success_floor_data_gas(self):
+        method = f"{self.ns}_estimateGas"
+        address = test_data_set["account"]["sender"]["address"]
+        contract = test_data_set["contracts"]["unknown"]["address"][0]
+        large_calldata = test_data_set["contracts"]["unknown"]["input"] + "ff" * 1000  # Function call + 1KB of data
+        params = [{"from": address, "to": contract, "data": large_calldata}]
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        self.assertIsNotNone(result)
+        estimated_gas = int(result, 16)
+        expected_gas = 61510
+        self.assertEqual(estimated_gas, expected_gas)
+
     def test_eth_estimateComputationCost_success(self):
         method = f"{self.ns}_estimateComputationCost"
         address = test_data_set["account"]["sender"]["address"]
@@ -1535,6 +1548,7 @@ class TestEthNamespaceTransactionWS(unittest.TestCase):
         suite.addTest(TestEthNamespaceTransactionWS("test_eth_estimateGas_error_evm_revert_message"))
         suite.addTest(TestEthNamespaceTransactionWS("test_eth_estimateGas_error_revert"))
         suite.addTest(TestEthNamespaceTransactionWS("test_eth_estimateGas_success"))
+        suite.addTest(TestEthNamespaceTransactionWS("test_eth_estimateGas_success_floor_data_gas"))
         suite.addTest(TestEthNamespaceTransactionWS("test_eth_getTransactionByHash_error_no_param"))
         suite.addTest(TestEthNamespaceTransactionWS("test_eth_getTransactionByHash_error_wrong_type_param"))
         suite.addTest(TestEthNamespaceTransactionWS("test_eth_getTransactionByHash_success_wrong_value_param"))

--- a/kaia/transaction/kaia_transaction_rpc.py
+++ b/kaia/transaction/kaia_transaction_rpc.py
@@ -1487,6 +1487,19 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
         _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
 
+    def test_kaia_estimateGas_success_floor_data_gas(self):
+        method = f"{self.ns}_estimateGas"
+        address = test_data_set["account"]["sender"]["address"]
+        contract = test_data_set["contracts"]["unknown"]["address"][0]
+        large_calldata = test_data_set["contracts"]["unknown"]["input"] + "ff" * 1000  # Function call + 1KB of data
+        params = [{"from": address, "to": contract, "data": large_calldata}]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        self.assertIsNotNone(result)
+        estimated_gas = int(result, 16)
+        expected_gas = 61510
+        self.assertEqual(estimated_gas, expected_gas)
+
     def test_kaia_estimateComputationCost_success(self):
         method = f"{self.ns}_estimateComputationCost"
         address = test_data_set["account"]["sender"]["address"]
@@ -1742,6 +1755,7 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
         suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_estimateGas_error_evm_revert_message"))
         suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_estimateGas_success"))
         suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_estimateGas_success_data_instead_input"))
+        suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_estimateGas_success_floor_data_gas"))
         suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_estimateComputationCost_success"))
         suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_estimateComputationCost_success_input_instead_data"))
         suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_getTransactionByHash_error_no_param"))

--- a/kaia/transaction/kaia_transaction_ws.py
+++ b/kaia/transaction/kaia_transaction_ws.py
@@ -1487,6 +1487,19 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         _, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
 
+    def test_kaia_estimateGas_success_floor_data_gas(self):
+        method = f"{self.ns}_estimateGas"
+        address = test_data_set["account"]["sender"]["address"]
+        contract = test_data_set["contracts"]["unknown"]["address"][0]
+        large_calldata = test_data_set["contracts"]["unknown"]["input"] + "ff" * 1000  # Function call + 1KB of data
+        params = [{"from": address, "to": contract, "data": large_calldata}]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        self.assertIsNotNone(result)
+        estimated_gas = int(result, 16)
+        expected_gas = 61510
+        self.assertEqual(estimated_gas, expected_gas)
+
     def test_kaia_estimateComputationCost_success(self):
         method = f"{self.ns}_estimateComputationCost"
         address = test_data_set["account"]["sender"]["address"]
@@ -1742,6 +1755,7 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_estimateGas_error_evm_revert_message"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_estimateGas_success"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_estimateGas_success_data_instead_input"))
+        suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_estimateGas_success_floor_data_gas"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_estimateComputationCost_success"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_estimateComputationCost_success_input_instead_data"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_getTransactionByHash_error_no_param"))


### PR DESCRIPTION
This PR adds test cases for EIP-7623
- We have recently [updated](https://github.com/kaiachain/kaia/pull/436) `DoEstimateGas` to handle `ErrFloorDataGas` so that it could try with a higher gas
- Therefore, we'd like to check if `{kaia,eth}_estimateGas` correctly calculates estimated gas for large calldata tx.

Before v2.0.3:
```
AssertionError: {'code': -32000, 'message': 'err: insufficient gas for floor data gas cost: have 50801, want 61510 (supplied gas 50801)'} is not None
```

After v2.0.3:
```
Running tests...
----------------------------------------------------------------------
 test_eth_estimateGas_success_floor_data_gas (eth.transaction.eth_transaction_rpc.TestEthNamespaceTransactionRPC.test_eth_estimateGas_success_floor_data_gas) ... OK (0.004275)s

----------------------------------------------------------------------
Ran 1 test in 0:00:00

OK
```