### PR TITLE
Improve tests with kaia-v2 APIs

### DIFF
--- a/debug/debug_ws.py
+++ b/debug/debug_ws.py
@@ -834,6 +834,54 @@ class TestDebugNamespaceWS(unittest.TestCase):
         # We need to implement this test case correctly.
         pass
 
+    def test_debug_isGaslessTx_success(self):
+        method = "kaia_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441406250)
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = "kaia_signTransaction"
+        params = [
+            {
+                "from": txFrom,
+                "to": txTo,
+                "gas": txGas,
+                "gasPrice": txGasPrice,
+                "value": txValue,
+                "nonce": nonce,
+            }
+        ]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        rawData = result["raw"]
+        method = f"{self.ns}_isGaslessTx"
+        params = [[rawData]]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        self.assertIsNotNone(result)
+        self.assertFalse(result["isGasless"])
+        self.assertEqual(result["reason"], "transaction is not a swap transaction")
+
+    def test_debug_gaslessInfo_success(self):
+        method = f"{self.ns}_gaslessInfo"
+        params = []
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        self.assertIsNotNone(result)
+        self.assertFalse(result["isDisabled"])
+        self.assertEqual(result["swapRouter"], "0x0000000000000000000000000000000000000000")
+        self.assertEqual(result["allowedTokens"], [])
+        self.assertEqual(result["maxBundleTxs"], 100)
+
     @staticmethod
     def suite():
         suite = unittest.TestSuite()
@@ -965,5 +1013,7 @@ class TestDebugNamespaceWS(unittest.TestCase):
         suite.addTest(TestDebugNamespaceWS("test_debug_standardTraceBlockToFile_success"))
         suite.addTest(TestDebugNamespaceWS("test_debug_traceBadBlock_success"))
         suite.addTest(TestDebugNamespaceWS("test_debug_standardTraceBadBlockToFile_success"))
+        suite.addTest(TestDebugNamespaceWS("test_debug_isGaslessTx_success"))
+        suite.addTest(TestDebugNamespaceWS("test_debug_gaslessInfo_success"))
 
         return suite

--- a/eth/account/eth_account_rpc.py
+++ b/eth/account/eth_account_rpc.py
@@ -244,15 +244,14 @@ class TestEthNamespaceAccountRPC(unittest.TestCase):
     @staticmethod
     def suite():
         suite = unittest.TestSuite()
+
         suite.addTest(TestEthNamespaceAccountRPC("test_eth_accounts_success_wrong_value_param"))
         suite.addTest(TestEthNamespaceAccountRPC("test_eth_accounts_success"))
 
         suite.addTest(TestEthNamespaceAccountRPC("test_eth_getBalance_error_no_param"))
-
         suite.addTest(TestEthNamespaceAccountRPC("test_eth_getBalance_error_wrong_type_param1"))
         suite.addTest(TestEthNamespaceAccountRPC("test_eth_getBalance_error_wrong_type_param2"))
         suite.addTest(TestEthNamespaceAccountRPC("test_eth_getBalance_error_wrong_value_param"))
-
         suite.addTest(TestEthNamespaceAccountRPC("test_eth_getBalance_success"))
 
         suite.addTest(TestEthNamespaceAccountRPC("test_eth_getTransactionCount_error_no_param"))

--- a/eth/account/eth_account_ws.py
+++ b/eth/account/eth_account_ws.py
@@ -244,15 +244,14 @@ class TestEthNamespaceAccountWS(unittest.TestCase):
     @staticmethod
     def suite():
         suite = unittest.TestSuite()
+
         suite.addTest(TestEthNamespaceAccountWS("test_eth_accounts_success_wrong_value_param"))
         suite.addTest(TestEthNamespaceAccountWS("test_eth_accounts_success"))
 
         suite.addTest(TestEthNamespaceAccountWS("test_eth_getBalance_error_no_param"))
-
         suite.addTest(TestEthNamespaceAccountWS("test_eth_getBalance_error_wrong_type_param1"))
         suite.addTest(TestEthNamespaceAccountWS("test_eth_getBalance_error_wrong_type_param2"))
         suite.addTest(TestEthNamespaceAccountWS("test_eth_getBalance_error_wrong_value_param"))
-
         suite.addTest(TestEthNamespaceAccountWS("test_eth_getBalance_success"))
 
         suite.addTest(TestEthNamespaceAccountWS("test_eth_getTransactionCount_error_no_param"))

--- a/eth/transaction/eth_transaction_rpc.py
+++ b/eth/transaction/eth_transaction_rpc.py
@@ -617,12 +617,14 @@ class TestEthNamespaceTransactionRPC(unittest.TestCase):
         params = []
         result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         Utils.check_error(self, "arg0NoParams", error)
+        self.assertIsNone(result)
 
     def test_eth_sendRawTransaction_error_wrong_type_param(self):
         method = f"{self.ns}_sendRawTransaction"
         params = ["abcd"]
         result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         Utils.check_error(self, "arg0HexToBytes", error)
+        self.assertIsNone(result)
 
     def test_eth_sendRawTransaction_success(self):
         Utils.waiting_count("Waiting for", 5, "seconds until writing a block")
@@ -653,12 +655,13 @@ class TestEthNamespaceTransactionRPC(unittest.TestCase):
         ]
         result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
-
         rawData = result["raw"]
+
         method = f"{self.ns}_sendRawTransaction"
         params = [rawData]
         result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
+        self.assertRegex(result, "^0x[0-9a-f]{64}$")
 
     def test_eth_sendRawTransaction_AccessList_error_wrong_prefix(self):
         method = f"{self.ns}_getTransactionCount"
@@ -669,7 +672,7 @@ class TestEthNamespaceTransactionRPC(unittest.TestCase):
         nonce, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
 
-        method = "kaia_chainID"
+        method = f"{self.ns}_chainId"
         params = []
         chainId, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
@@ -706,19 +709,21 @@ class TestEthNamespaceTransactionRPC(unittest.TestCase):
 
         testSize = 300
         for i in range(0, testSize):
-            randomPrefix = hex(random.randint(3, 256))
+            # start=2: make bigger than TxTypeEthereumAccessList:0x7801 without "0x78" prefix
+            # end=256: make within 1 byte for excluding "0x78" prefix
+            randomPrefix = hex(random.randint(2, 256))
             if len(randomPrefix) % 2 == 1:
                 randomPrefix = f"0x0{randomPrefix[2:]}"
             rawTx = randomPrefix + rawTxWithoutHexPrefix
             method = f"{self.ns}_sendRawTransaction"
             params = [rawTx]
-            _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+            result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
             self.assertIsNotNone(error)
-            self.assertTrue(
-                "undefined tx type" in error["message"] or "rlp:" in error["message"],
-            )
+            self.assertTrue("undefined tx type" in error["message"] or "rlp:" in error["message"])
+            self.assertIsNone(result)
 
-    def test_eth_sendRawTransaction_DynamicFee_error_wrong_prefix(self):
+    def test_eth_sendRawTransaction_AccessList_success(self):
+        Utils.waiting_count("Waiting for", 5, "seconds until writing a block")
         method = f"{self.ns}_getTransactionCount"
         tag = "latest"
         txFrom = test_data_set["account"]["sender"]["address"]
@@ -727,14 +732,14 @@ class TestEthNamespaceTransactionRPC(unittest.TestCase):
         nonce, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
 
-        method = "kaia_chainID"
+        method = f"{self.ns}_chainId"
         params = []
         chainId, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
 
         password = test_data_set["account"]["sender"]["password"]
         txTo = test_data_set["account"]["sender"]["address"]
-        txGas = hex(60400)
+        txGas = hex(30400)
         txGasPrice = test_data_set["unitGasPrice"]
         txValue = hex(2441)
         storageKeys = [
@@ -746,11 +751,54 @@ class TestEthNamespaceTransactionRPC(unittest.TestCase):
             "from": txFrom,
             "to": txTo,
             "gas": txGas,
+            "gasPrice": txGasPrice,
+            "value": txValue,
+            "nonce": nonce,
+            "accessList": accessList,
+            "chainId": chainId,
+            "typeInt": 30721,
+        }
+
+        method = f"{self.ns}_signTransaction"
+        params = [transaction]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        rawData = result["raw"]
+
+        method = f"{self.ns}_sendRawTransaction"
+        params = [rawData]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        self.assertRegex(result, "^0x[0-9a-f]{64}$")
+
+    def test_eth_sendRawTransaction_DynamicFee_error_wrong_prefix(self):
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_chainId"
+        params = []
+        chainId, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(60400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441)
+        transaction = {
+            "from": txFrom,
+            "to": txTo,
+            "gas": txGas,
             "maxPriorityFeePerGas": txGasPrice,
             "maxFeePerGas": txGasPrice,
             "value": txValue,
             "nonce": nonce,
-            "accessList": accessList,
+            "accessList": [],
             "chainId": chainId,
             "typeInt": 30722,
         }
@@ -765,17 +813,63 @@ class TestEthNamespaceTransactionRPC(unittest.TestCase):
 
         testSize = 300
         for i in range(0, testSize):
+            # start=3: make bigger than TxTypeEthereumDynamicFee:0x7802 without "0x78" prefix
+            # end=256: make within 1 byte for excluding "0x78" prefix
             randomPrefix = hex(random.randint(3, 256))
             if len(randomPrefix) % 2 == 1:
                 randomPrefix = f"0x0{randomPrefix[2:]}"
             rawTx = randomPrefix + rawTxWithoutHexPrefix
             method = f"{self.ns}_sendRawTransaction"
             params = [rawTx]
-            _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+            result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
             self.assertIsNotNone(error)
-            self.assertTrue(
-                "undefined tx type" in error["message"] or "rlp:" in error["message"],
-            )
+            self.assertTrue("undefined tx type" in error["message"] or "rlp:" in error["message"])
+            self.assertIsNone(result)
+
+    def test_eth_sendRawTransaction_DynamicFee_success(self):
+        Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_chainId"
+        params = []
+        chainId, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(60400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441)
+        transaction = {
+            "from": txFrom,
+            "to": txTo,
+            "gas": txGas,
+            "maxPriorityFeePerGas": txGasPrice,
+            "maxFeePerGas": txGasPrice,
+            "value": txValue,
+            "nonce": nonce,
+            "accessList": [],
+            "chainId": chainId,
+            "typeInt": 30722,
+        }
+
+        method = f"{self.ns}_signTransaction"
+        params = [transaction]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        rawData = result["raw"]
+
+        method = f"{self.ns}_sendRawTransaction"
+        params = [rawData]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        self.assertRegex(result, "^0x[0-9a-f]{64}$")
 
     def test_eth_sendRawTransaction_SetCode_error_wrong_prefix(self):
         method = f"{self.ns}_getTransactionCount"
@@ -826,11 +920,13 @@ class TestEthNamespaceTransactionRPC(unittest.TestCase):
         self.assertIsNone(error)
 
         rawData = result["raw"]
-        rawTxWithoutHexPrefix = rawData[6:]
+        rawTxWithoutHexPrefix = rawData[4:]
 
         testSize = 300
         for i in range(0, testSize):
-            randomPrefix = hex(random.randint(81, 30720))
+            # start=5: make bigger than TxTypeEthereumSetCode:0x7804 without "0x78" prefix
+            # end=256: make within 1 byte for excluding "0x78" prefix
+            randomPrefix = hex(random.randint(5, 256))
             if len(randomPrefix) % 2 == 1:
                 randomPrefix = f"0x0{randomPrefix[2:]}"
             rawTx = randomPrefix + rawTxWithoutHexPrefix
@@ -839,6 +935,7 @@ class TestEthNamespaceTransactionRPC(unittest.TestCase):
             result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
             self.assertIsNotNone(error)
             self.assertTrue("undefined tx type" in error["message"] or "rlp:" in error["message"])
+            self.assertIsNone(result)
 
     def test_eth_sendRawTransaction_SetCode_success(self):
         Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
@@ -888,12 +985,13 @@ class TestEthNamespaceTransactionRPC(unittest.TestCase):
         params = [transaction]
         result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
-
         rawData = result["raw"]
+
         method = f"{self.ns}_sendRawTransaction"
         params = [rawData]
-        txHash, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
+        self.assertRegex(result, "^0x[0-9a-f]{64}$")
 
     def test_eth_getTransactionByBlockHashAndIndex_error_no_param(self):
         method = f"{self.ns}_getTransactionByBlockHashAndIndex"
@@ -1653,7 +1751,10 @@ class TestEthNamespaceTransactionRPC(unittest.TestCase):
         suite.addTest(TestEthNamespaceTransactionRPC("test_eth_sendRawTransaction_error_wrong_type_param"))
         suite.addTest(TestEthNamespaceTransactionRPC("test_eth_sendRawTransaction_success"))
         suite.addTest(TestEthNamespaceTransactionRPC("test_eth_sendRawTransaction_AccessList_error_wrong_prefix"))
+        suite.addTest(TestEthNamespaceTransactionRPC("test_eth_sendRawTransaction_AccessList_success"))
+        
         suite.addTest(TestEthNamespaceTransactionRPC("test_eth_sendRawTransaction_DynamicFee_error_wrong_prefix"))
+        suite.addTest(TestEthNamespaceTransactionRPC("test_eth_sendRawTransaction_DynamicFee_success"))
         suite.addTest(TestEthNamespaceTransactionRPC("test_eth_sendRawTransaction_SetCode_error_wrong_prefix"))
         suite.addTest(TestEthNamespaceTransactionRPC("test_eth_sendRawTransaction_SetCode_success"))
 

--- a/eth/transaction/eth_transaction_rpc.py
+++ b/eth/transaction/eth_transaction_rpc.py
@@ -777,6 +777,124 @@ class TestEthNamespaceTransactionRPC(unittest.TestCase):
                 "undefined tx type" in error["message"] or "rlp:" in error["message"],
             )
 
+    def test_eth_sendRawTransaction_SetCode_error_wrong_prefix(self):
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_chainId"
+        params = []
+        chainId, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(60400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441)
+        authorizationList = [
+            {
+                "chainId": "0x0",
+                "address": "0x000000000000000000000000000000000000aaaa",
+                "nonce": "0x0",
+                "yParity": "0x1",
+                "r": "0x79eae4cbf85eae84eac1311d7384f4f3bca88078cde0dbf0203248b074b7c36d",
+                "s": "0x8ea1adf9dded4d8223bd6784a6bf711211b381f04a34e9bea39e3ea81213d32",
+            },
+        ]
+        transaction = {
+            "from": txFrom,
+            "to": txTo,
+            "gas": txGas,
+            "maxPriorityFeePerGas": txGasPrice,
+            "maxFeePerGas": txGasPrice,
+            "value": txValue,
+            "nonce": nonce,
+            "accessList": [],
+            "authorizationList": authorizationList,
+            "chainId": chainId,
+            "typeInt": 30724, # Type4
+        }
+
+        method = f"{self.ns}_signTransaction"
+        params = [transaction]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        rawData = result["raw"]
+        rawTxWithoutHexPrefix = rawData[6:]
+
+        testSize = 300
+        for i in range(0, testSize):
+            randomPrefix = hex(random.randint(81, 30720))
+            if len(randomPrefix) % 2 == 1:
+                randomPrefix = f"0x0{randomPrefix[2:]}"
+            rawTx = randomPrefix + rawTxWithoutHexPrefix
+            method = f"{self.ns}_sendRawTransaction"
+            params = [rawTx]
+            result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+            self.assertIsNotNone(error)
+            self.assertTrue("undefined tx type" in error["message"] or "rlp:" in error["message"])
+
+    def test_eth_sendRawTransaction_SetCode_success(self):
+        Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_chainId"
+        params = []
+        chainId, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(60400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441)
+        authorizationList = [
+            {
+                "chainId": "0x0",
+                "address": "0x000000000000000000000000000000000000aaaa",
+                "nonce": "0x0",
+                "yParity": "0x1",
+                "r": "0x79eae4cbf85eae84eac1311d7384f4f3bca88078cde0dbf0203248b074b7c36d",
+                "s": "0x8ea1adf9dded4d8223bd6784a6bf711211b381f04a34e9bea39e3ea81213d32",
+            },
+        ]
+        transaction = {
+            "from": txFrom,
+            "to": txTo,
+            "gas": txGas,
+            "maxPriorityFeePerGas": txGasPrice,
+            "maxFeePerGas": txGasPrice,
+            "value": txValue,
+            "nonce": nonce,
+            "accessList": [],
+            "authorizationList": authorizationList,
+            "chainId": chainId,
+            "typeInt": 30724, # Type4
+        }
+
+        method = f"{self.ns}_signTransaction"
+        params = [transaction]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        rawData = result["raw"]
+        method = f"{self.ns}_sendRawTransaction"
+        params = [rawData]
+        txHash, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
     def test_eth_getTransactionByBlockHashAndIndex_error_no_param(self):
         method = f"{self.ns}_getTransactionByBlockHashAndIndex"
 
@@ -1536,6 +1654,9 @@ class TestEthNamespaceTransactionRPC(unittest.TestCase):
         suite.addTest(TestEthNamespaceTransactionRPC("test_eth_sendRawTransaction_success"))
         suite.addTest(TestEthNamespaceTransactionRPC("test_eth_sendRawTransaction_AccessList_error_wrong_prefix"))
         suite.addTest(TestEthNamespaceTransactionRPC("test_eth_sendRawTransaction_DynamicFee_error_wrong_prefix"))
+        suite.addTest(TestEthNamespaceTransactionRPC("test_eth_sendRawTransaction_SetCode_error_wrong_prefix"))
+        suite.addTest(TestEthNamespaceTransactionRPC("test_eth_sendRawTransaction_SetCode_success"))
+
         suite.addTest(TestEthNamespaceTransactionRPC("test_eth_getTransactionByBlockHashAndIndex_error_no_param"))
         suite.addTest(
             TestEthNamespaceTransactionRPC("test_eth_getTransactionByBlockHashAndIndex_error_wrong_type_param")

--- a/kaia/account/kaia_account_rpc.py
+++ b/kaia/account/kaia_account_rpc.py
@@ -210,8 +210,9 @@ class TestKaiaNamespaceAccountRPC(unittest.TestCase):
         address = test_data_set["account"]["sender"]["address"]
         tag = "latest"
         params = [address, tag]
-        _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
+        self.assertFalse(result) # EOA
 
     def test_kaia_isContractAccount_success_eoa_with_code(self):
         method = f"{self.ns}_isContractAccount"
@@ -220,7 +221,7 @@ class TestKaiaNamespaceAccountRPC(unittest.TestCase):
         params = [address, tag]
         result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
-        self.assertTrue(result)
+        self.assertTrue(result) # EOA with code
 
     def test_kaia_getTransactionCount_error_no_param(self):
         method = f"{self.ns}_getTransactionCount"

--- a/kaia/account/kaia_account_rpc.py
+++ b/kaia/account/kaia_account_rpc.py
@@ -88,14 +88,18 @@ class TestKaiaNamespaceAccountRPC(unittest.TestCase):
     def test_kaia_getAccount_success(self):
         address = test_data_set["account"]["sender"]["address"]
         method = f"{self.ns}_getAccount"
-        _, error = Utils.call_rpc(self.endpoint, method, [address, "latest"], self.log_path)
+        result, error = Utils.call_rpc(self.endpoint, method, [address, "latest"], self.log_path)
         self.assertIsNone(error)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["accType"], 1) # EOA
 
     def test_kaia_getAccount_success_eoa_with_code(self):
         address = test_data_set["account"]["eoaWithCode"]["address"]
         method = f"{self.ns}_getAccount"
         result, error = Utils.call_rpc(self.endpoint, method, [address, "latest"], self.log_path)
         self.assertIsNone(error)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["accType"], 1) # EOA
         kaia_common.checkIfEoaFollowKIP228(self, result)
 
     def test_kaia_getAccountKey_error_no_param(self):
@@ -374,17 +378,17 @@ class TestKaiaNamespaceAccountRPC(unittest.TestCase):
         suite.addTest(TestKaiaNamespaceAccountRPC("test_kaia_getAccount_error_wrong_value_param1"))
         suite.addTest(TestKaiaNamespaceAccountRPC("test_kaia_getAccount_success"))
         suite.addTest(TestKaiaNamespaceAccountRPC("test_kaia_getAccount_success_eoa_with_code"))
+
         suite.addTest(TestKaiaNamespaceAccountRPC("test_kaia_getAccountKey_error_no_param"))
         suite.addTest(TestKaiaNamespaceAccountRPC("test_kaia_getAccountKey_error_wrong_type_param1"))
         suite.addTest(TestKaiaNamespaceAccountRPC("test_kaia_getAccountKey_error_wrong_type_param2"))
         suite.addTest(TestKaiaNamespaceAccountRPC("test_kaia_getAccountKey_error_wrong_value_param1"))
         suite.addTest(TestKaiaNamespaceAccountRPC("test_kaia_getAccountKey_success"))
-        suite.addTest(TestKaiaNamespaceAccountRPC("test_kaia_getBalance_error_no_param"))
 
+        suite.addTest(TestKaiaNamespaceAccountRPC("test_kaia_getBalance_error_no_param"))
         suite.addTest(TestKaiaNamespaceAccountRPC("test_kaia_getBalance_error_wrong_type_param1"))
         suite.addTest(TestKaiaNamespaceAccountRPC("test_kaia_getBalance_error_wrong_type_param2"))
         suite.addTest(TestKaiaNamespaceAccountRPC("test_kaia_getBalance_error_wrong_value_param"))
-
         suite.addTest(TestKaiaNamespaceAccountRPC("test_kaia_getBalance_success"))
 
         suite.addTest(TestKaiaNamespaceAccountRPC("test_kaia_isContractAccount_error_no_param"))

--- a/kaia/account/kaia_account_ws.py
+++ b/kaia/account/kaia_account_ws.py
@@ -88,14 +88,18 @@ class TestKaiaNamespaceAccountWS(unittest.TestCase):
     def test_kaia_getAccount_success(self):
         address = test_data_set["account"]["sender"]["address"]
         method = f"{self.ns}_getAccount"
-        _, error = Utils.call_ws(self.endpoint, method, [address, "latest"], self.log_path)
+        result, error = Utils.call_ws(self.endpoint, method, [address, "latest"], self.log_path)
         self.assertIsNone(error)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["accType"], 1) # EOA
 
     def test_kaia_getAccount_success_eoa_with_code(self):
         address = test_data_set["account"]["eoaWithCode"]["address"]
         method = f"{self.ns}_getAccount"
         result, error = Utils.call_ws(self.endpoint, method, [address, "latest"], self.log_path)
         self.assertIsNone(error)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["accType"], 1) # EOA
         kaia_common.checkIfEoaFollowKIP228(self, result)
 
     def test_kaia_getAccountKey_error_no_param(self):
@@ -374,17 +378,17 @@ class TestKaiaNamespaceAccountWS(unittest.TestCase):
         suite.addTest(TestKaiaNamespaceAccountWS("test_kaia_getAccount_error_wrong_value_param1"))
         suite.addTest(TestKaiaNamespaceAccountWS("test_kaia_getAccount_success"))
         suite.addTest(TestKaiaNamespaceAccountWS("test_kaia_getAccount_success_eoa_with_code"))
+
         suite.addTest(TestKaiaNamespaceAccountWS("test_kaia_getAccountKey_error_no_param"))
         suite.addTest(TestKaiaNamespaceAccountWS("test_kaia_getAccountKey_error_wrong_type_param1"))
         suite.addTest(TestKaiaNamespaceAccountWS("test_kaia_getAccountKey_error_wrong_type_param2"))
         suite.addTest(TestKaiaNamespaceAccountWS("test_kaia_getAccountKey_error_wrong_value_param1"))
         suite.addTest(TestKaiaNamespaceAccountWS("test_kaia_getAccountKey_success"))
-        suite.addTest(TestKaiaNamespaceAccountWS("test_kaia_getBalance_error_no_param"))
 
+        suite.addTest(TestKaiaNamespaceAccountWS("test_kaia_getBalance_error_no_param"))
         suite.addTest(TestKaiaNamespaceAccountWS("test_kaia_getBalance_error_wrong_type_param1"))
         suite.addTest(TestKaiaNamespaceAccountWS("test_kaia_getBalance_error_wrong_type_param2"))
         suite.addTest(TestKaiaNamespaceAccountWS("test_kaia_getBalance_error_wrong_value_param"))
-
         suite.addTest(TestKaiaNamespaceAccountWS("test_kaia_getBalance_success"))
 
         suite.addTest(TestKaiaNamespaceAccountWS("test_kaia_isContractAccount_error_no_param"))

--- a/kaia/account/kaia_account_ws.py
+++ b/kaia/account/kaia_account_ws.py
@@ -210,8 +210,9 @@ class TestKaiaNamespaceAccountWS(unittest.TestCase):
         address = test_data_set["account"]["sender"]["address"]
         tag = "latest"
         params = [address, tag]
-        _, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
+        self.assertFalse(result) # EOA
 
     def test_kaia_isContractAccount_success_eoa_with_code(self):
         method = f"{self.ns}_isContractAccount"
@@ -220,7 +221,7 @@ class TestKaiaNamespaceAccountWS(unittest.TestCase):
         params = [address, tag]
         result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
-        self.assertTrue(result)
+        self.assertTrue(result) # EOA with code
 
     def test_kaia_getTransactionCount_error_no_param(self):
         method = f"{self.ns}_getTransactionCount"

--- a/kaia/configuration/kaia_configuration_rpc.py
+++ b/kaia/configuration/kaia_configuration_rpc.py
@@ -133,6 +133,18 @@ class TestKaiaNamespaceConfigurationRPC(unittest.TestCase):
         _, error = Utils.call_rpc(self.endpoint, method, [], self.log_path)
         self.assertIsNone(error)
 
+    def test_kaia_isConsoleLogEnabled_success_wrong_value_param(self):
+        method = f"{self.ns}_isConsoleLogEnabled"
+        result, error = Utils.call_rpc(self.endpoint, method, ["abcd"], self.log_path)
+        self.assertIsNone(error)
+        self.assertEqual(result, False) # as default value
+
+    def test_kaia_isConsoleLogEnabled_success(self):
+        method = f"{self.ns}_isConsoleLogEnabled"
+        result, error = Utils.call_rpc(self.endpoint, method, [], self.log_path)
+        self.assertIsNone(error)
+        self.assertEqual(result, False) # as default value
+
     @staticmethod
     def suite():
         suite = unittest.TestSuite()
@@ -160,4 +172,6 @@ class TestKaiaNamespaceConfigurationRPC(unittest.TestCase):
         suite.addTest(TestKaiaNamespaceConfigurationRPC("test_kaia_getParams_success_with_value_param"))
         suite.addTest(TestKaiaNamespaceConfigurationRPC("test_kaia_getParams_error_wrong_type_value"))
         suite.addTest(TestKaiaNamespaceConfigurationRPC("test_kaia_getParams_success_without_value_param"))
+        suite.addTest(TestKaiaNamespaceConfigurationRPC("test_kaia_isConsoleLogEnabled_success_wrong_value_param"))
+        suite.addTest(TestKaiaNamespaceConfigurationRPC("test_kaia_isConsoleLogEnabled_success"))
         return suite

--- a/kaia/configuration/kaia_configuration_ws.py
+++ b/kaia/configuration/kaia_configuration_ws.py
@@ -133,6 +133,18 @@ class TestKaiaNamespaceConfigurationWS(unittest.TestCase):
         _, error = Utils.call_ws(self.endpoint, method, [], self.log_path)
         self.assertIsNone(error)
 
+    def test_kaia_isConsoleLogEnabled_success_wrong_value_param(self):
+        method = f"{self.ns}_isConsoleLogEnabled"
+        result, error = Utils.call_ws(self.endpoint, method, ["abcd"], self.log_path)
+        self.assertIsNone(error)
+        self.assertEqual(result, False) # as default value
+
+    def test_kaia_isConsoleLogEnabled_success(self):
+        method = f"{self.ns}_isConsoleLogEnabled"
+        result, error = Utils.call_ws(self.endpoint, method, [], self.log_path)
+        self.assertIsNone(error)
+        self.assertEqual(result, False) # as default value
+
     @staticmethod
     def suite():
         suite = unittest.TestSuite()
@@ -160,5 +172,6 @@ class TestKaiaNamespaceConfigurationWS(unittest.TestCase):
         suite.addTest(TestKaiaNamespaceConfigurationWS("test_kaia_getParams_success_with_value_param"))
         suite.addTest(TestKaiaNamespaceConfigurationWS("test_kaia_getParams_error_wrong_type_value"))
         suite.addTest(TestKaiaNamespaceConfigurationWS("test_kaia_getParams_success_without_value_param"))
-
+        suite.addTest(TestKaiaNamespaceConfigurationWS("test_kaia_isConsoleLogEnabled_success_wrong_value_param"))
+        suite.addTest(TestKaiaNamespaceConfigurationWS("test_kaia_isConsoleLogEnabled_success"))
         return suite

--- a/kaia/transaction/kaia_transaction_rpc.py
+++ b/kaia/transaction/kaia_transaction_rpc.py
@@ -914,6 +914,124 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
         txHash, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
 
+    def test_kaia_sendRawTransaction_SetCode_error_wrong_prefix(self):
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_chainId"
+        params = []
+        chainId, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(60400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441)
+        authorizationList = [
+            {
+                "chainId": "0x0",
+                "address": "0x000000000000000000000000000000000000aaaa",
+                "nonce": "0x0",
+                "yParity": "0x1",
+                "r": "0x79eae4cbf85eae84eac1311d7384f4f3bca88078cde0dbf0203248b074b7c36d",
+                "s": "0x8ea1adf9dded4d8223bd6784a6bf711211b381f04a34e9bea39e3ea81213d32",
+            },
+        ]
+        transaction = {
+            "from": txFrom,
+            "to": txTo,
+            "gas": txGas,
+            "maxPriorityFeePerGas": txGasPrice,
+            "maxFeePerGas": txGasPrice,
+            "value": txValue,
+            "nonce": nonce,
+            "accessList": [],
+            "authorizationList": authorizationList,
+            "chainId": chainId,
+            "typeInt": 30724, # Type4
+        }
+
+        method = f"{self.ns}_signTransaction"
+        params = [transaction]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        rawData = result["raw"]
+        rawTxWithoutHexPrefix = rawData[6:]
+
+        testSize = 300
+        for i in range(0, testSize):
+            randomPrefix = hex(random.randint(81, 30720))
+            if len(randomPrefix) % 2 == 1:
+                randomPrefix = f"0x0{randomPrefix[2:]}"
+            rawTx = randomPrefix + rawTxWithoutHexPrefix
+            method = f"{self.ns}_sendRawTransaction"
+            params = [rawTx]
+            result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+            self.assertIsNotNone(error)
+            self.assertTrue("undefined tx type" in error["message"] or "rlp:" in error["message"])
+
+    def test_kaia_sendRawTransaction_SetCode_success(self):
+        Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_chainId"
+        params = []
+        chainId, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(60400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441)
+        authorizationList = [
+            {
+                "chainId": "0x0",
+                "address": "0x000000000000000000000000000000000000aaaa",
+                "nonce": "0x0",
+                "yParity": "0x1",
+                "r": "0x79eae4cbf85eae84eac1311d7384f4f3bca88078cde0dbf0203248b074b7c36d",
+                "s": "0x8ea1adf9dded4d8223bd6784a6bf711211b381f04a34e9bea39e3ea81213d32",
+            },
+        ]
+        transaction = {
+            "from": txFrom,
+            "to": txTo,
+            "gas": txGas,
+            "maxPriorityFeePerGas": txGasPrice,
+            "maxFeePerGas": txGasPrice,
+            "value": txValue,
+            "nonce": nonce,
+            "accessList": [],
+            "authorizationList": authorizationList,
+            "chainId": chainId,
+            "typeInt": 30724, # Type4
+        }
+
+        method = f"{self.ns}_signTransaction"
+        params = [transaction]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        rawData = result["raw"]
+        method = f"{self.ns}_sendRawTransaction"
+        params = [rawData]
+        txHash, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
     def test_kaia_getTransactionByBlockHashAndIndex_error_no_param(self):
         method = f"{self.ns}_getTransactionByBlockHashAndIndex"
 
@@ -1771,6 +1889,9 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
         suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_createAccessList_success"))
         suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_sendRawTransaction_DynamicFee_error_wrong_prefix"))
         suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_sendRawTransaction_DynamicFee_success"))
+        suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_sendRawTransaction_SetCode_error_wrong_prefix"))
+        suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_sendRawTransaction_SetCode_success"))
+
         suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_getTransactionByBlockHashAndIndex_error_no_param"))
         suite.addTest(
             TestKaiaNamespaceTransactionRPC("test_kaia_getTransactionByBlockHashAndIndex_error_wrong_type_param")

--- a/kaia/transaction/kaia_transaction_rpc.py
+++ b/kaia/transaction/kaia_transaction_rpc.py
@@ -1601,7 +1601,7 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
         ]
         _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         #Utils.check_error(self, "GasRequiredExceedsAllowance", error)
-        self.assertIsNone(error) # The way "arg.Gas" is handled is different
+        self.assertIsNone(error) # "arg.Gas" is handled differently
 
     def test_kaia_estimateGas_error_evm_revert_message(self):
         method = f"{self.ns}_estimateGas"

--- a/kaia/transaction/kaia_transaction_rpc.py
+++ b/kaia/transaction/kaia_transaction_rpc.py
@@ -648,15 +648,18 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
         params = []
         result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         Utils.check_error(self, "arg0NoParams", error)
+        self.assertIsNone(result)
 
     def test_kaia_sendRawTransaction_error_wrong_type_param(self):
         method = f"{self.ns}_sendRawTransaction"
         params = ["abcd"]
         result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         Utils.check_error(self, "arg0HexToBytes", error)
+        self.assertIsNone(result)
 
     def test_kaia_sendRawTransaction_success(self):
         Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
+
         method = f"{self.ns}_getTransactionCount"
         tag = "latest"
         txFrom = test_data_set["account"]["sender"]["address"]
@@ -683,12 +686,13 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
         ]
         result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
-
         rawData = result["raw"]
+
         method = f"{self.ns}_sendRawTransaction"
         params = [rawData]
         result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
+        self.assertRegex(result, "^0x[0-9a-f]{64}$")
 
     def test_kaia_sendRawTransaction_AccessList_error_wrong_prefix(self):
         method = f"{self.ns}_getTransactionCount"
@@ -699,7 +703,7 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
         nonce, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
 
-        method = f"{self.ns}_chainID"
+        method = f"{self.ns}_chainId"
         params = []
         chainId, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
@@ -736,6 +740,8 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
 
         testSize = 300
         for i in range(0, testSize):
+            # start=81: make bigger than TxTypeKaiaLast:80
+            # end=30720: make smaller than EthereumTxTypeEnvelope:"0x78"+"00"=0x7800
             randomPrefix = hex(random.randint(81, 30720))
             if len(randomPrefix) % 2 == 1:
                 randomPrefix = f"0x0{randomPrefix[2:]}"
@@ -745,9 +751,10 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
             result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
             self.assertIsNotNone(error)
             self.assertTrue("undefined tx type" in error["message"] or "rlp:" in error["message"])
+            self.assertIsNone(result)
 
     def test_kaia_sendRawTransaction_AccessList_success(self):
-        Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
+        Utils.waiting_count("Waiting for", 5, "seconds until writing a block")
         method = f"{self.ns}_getTransactionCount"
         tag = "latest"
         txFrom = test_data_set["account"]["sender"]["address"]
@@ -756,7 +763,7 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
         nonce, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
 
-        method = f"{self.ns}_chainID"
+        method = f"{self.ns}_chainId"
         params = []
         chainId, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
@@ -787,12 +794,13 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
         params = [transaction]
         result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
+        rawData = result["raw"]
 
         method = f"{self.ns}_sendRawTransaction"
-        rawData = result["raw"]
         params = [rawData]
         result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
+        self.assertRegex(result, "^0x[0-9a-f]{64}$")
 
     def test_kaia_createAccessList_success(self):
         method = f"{self.ns}_createAccessList"
@@ -817,7 +825,7 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
         nonce, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
 
-        method = f"{self.ns}_chainID"
+        method = f"{self.ns}_chainId"
         params = []
         chainId, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
@@ -827,11 +835,6 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
         txGas = hex(60400)
         txGasPrice = test_data_set["unitGasPrice"]
         txValue = hex(2441)
-        storageKeys = [
-            "0x0000000000000000000000000000000000000000000000000000000000000003",
-            "0x0000000000000000000000000000000000000000000000000000000000000007",
-        ]
-        accessList = [{"address": txFrom, "storageKeys": storageKeys}]
         transaction = {
             "from": txFrom,
             "to": txTo,
@@ -840,7 +843,7 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
             "maxFeePerGas": txGasPrice,
             "value": txValue,
             "nonce": nonce,
-            "accessList": accessList,
+            "accessList": [],
             "chainId": chainId,
             "typeInt": 30722,
         }
@@ -855,6 +858,8 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
 
         testSize = 300
         for i in range(0, testSize):
+            # start=81: make bigger than TxTypeKaiaLast:80
+            # end=30720: make smaller than EthereumTxTypeEnvelope:"0x78"+"00"=0x7800
             randomPrefix = hex(random.randint(81, 30720))
             if len(randomPrefix) % 2 == 1:
                 randomPrefix = f"0x0{randomPrefix[2:]}"
@@ -864,6 +869,7 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
             result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
             self.assertIsNotNone(error)
             self.assertTrue("undefined tx type" in error["message"] or "rlp:" in error["message"])
+            self.assertIsNone(result)
 
     def test_kaia_sendRawTransaction_DynamicFee_success(self):
         Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
@@ -875,7 +881,7 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
         nonce, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
 
-        method = f"{self.ns}_chainID"
+        method = f"{self.ns}_chainId"
         params = []
         chainId, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
@@ -885,11 +891,6 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
         txGas = hex(60400)
         txGasPrice = test_data_set["unitGasPrice"]
         txValue = hex(2441)
-        storageKeys = [
-            "0x0000000000000000000000000000000000000000000000000000000000000003",
-            "0x0000000000000000000000000000000000000000000000000000000000000007",
-        ]
-        accessList = [{"address": txFrom, "storageKeys": storageKeys}]
         transaction = {
             "from": txFrom,
             "to": txTo,
@@ -898,7 +899,7 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
             "maxFeePerGas": txGasPrice,
             "value": txValue,
             "nonce": nonce,
-            "accessList": accessList,
+            "accessList": [],
             "chainId": chainId,
             "typeInt": 30722,
         }
@@ -907,12 +908,13 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
         params = [transaction]
         result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
-
         rawData = result["raw"]
+
         method = f"{self.ns}_sendRawTransaction"
         params = [rawData]
-        txHash, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
+        self.assertRegex(result, "^0x[0-9a-f]{64}$")
 
     def test_kaia_sendRawTransaction_SetCode_error_wrong_prefix(self):
         method = f"{self.ns}_getTransactionCount"
@@ -967,6 +969,8 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
 
         testSize = 300
         for i in range(0, testSize):
+            # start=81: make bigger than TxTypeKaiaLast:80
+            # end=30720: make smaller than EthereumTxTypeEnvelope:"0x78"+"00"=7800
             randomPrefix = hex(random.randint(81, 30720))
             if len(randomPrefix) % 2 == 1:
                 randomPrefix = f"0x0{randomPrefix[2:]}"
@@ -976,6 +980,7 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
             result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
             self.assertIsNotNone(error)
             self.assertTrue("undefined tx type" in error["message"] or "rlp:" in error["message"])
+            self.assertIsNone(result)
 
     def test_kaia_sendRawTransaction_SetCode_success(self):
         Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
@@ -1025,12 +1030,13 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
         params = [transaction]
         result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
-
         rawData = result["raw"]
+
         method = f"{self.ns}_sendRawTransaction"
         params = [rawData]
-        txHash, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
+        self.assertRegex(result, "^0x[0-9a-f]{64}$")
 
     def test_kaia_getTransactionByBlockHashAndIndex_error_no_param(self):
         method = f"{self.ns}_getTransactionByBlockHashAndIndex"
@@ -1844,6 +1850,379 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
         _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
 
+    def test_kaia_sendRawTransactions_error_no_param(self):
+        method = f"{self.ns}_sendRawTransactions"
+        params = []
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        Utils.check_error(self, "arg0NoParams", error)
+        self.assertIsNone(result)
+
+    def test_kaia_sendRawTransactions_error_wrong_type_param(self):
+        method = f"{self.ns}_sendRawTransactions"
+        params = [["abcd"]]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        Utils.check_error(self, "arg0HexToBytes", error)
+        self.assertIsNone(result)
+
+    def test_kaia_sendRawTransactions_success(self):
+        Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441406250)
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_signTransaction"
+        params = [
+            {
+                "from": txFrom,
+                "to": txTo,
+                "gas": txGas,
+                "gasPrice": txGasPrice,
+                "value": txValue,
+                "nonce": nonce,
+            }
+        ]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        rawData = result["raw"]
+
+        method = f"{self.ns}_sendRawTransactions"
+        params = [[rawData]]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        self.assertEqual(len(result), 1)
+        self.assertRegex(result[0], "^0x[0-9a-f]{64}$")
+
+    def test_kaia_sendRawTransactions_AccessList_error_kaia_signTransaction(self):
+        Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_chainId"
+        params = []
+        chainId, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441)
+        storageKeys = [
+            "0x0000000000000000000000000000000000000000000000000000000000000003",
+            "0x0000000000000000000000000000000000000000000000000000000000000007",
+        ]
+        accessList = [{"address": txFrom, "storageKeys": storageKeys}]
+        transaction = {
+            "from": txFrom,
+            "to": txTo,
+            "gas": txGas,
+            "gasPrice": txGasPrice,
+            "value": txValue,
+            "nonce": nonce,
+            "accessList": accessList,
+            "chainId": chainId,
+            "typeInt": 30721,
+        }
+
+        method = "kaia_signTransaction" # kaia_signTransaction is not supported
+        params = [transaction]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        rawData = result["raw"]
+
+        method = f"{self.ns}_sendRawTransactions"
+        params = [[rawData]]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNotNone(error)
+        self.assertTrue("undefined tx type" in error["message"])
+        self.assertIsNone(result)
+
+    def test_kaia_sendRawTransactions_AccessList_success_eth_signTransaction(self):
+        Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_chainId"
+        params = []
+        chainId, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441)
+        storageKeys = [
+            "0x0000000000000000000000000000000000000000000000000000000000000003",
+            "0x0000000000000000000000000000000000000000000000000000000000000007",
+        ]
+        accessList = [{"address": txFrom, "storageKeys": storageKeys}]
+        transaction = {
+            "from": txFrom,
+            "to": txTo,
+            "gas": txGas,
+            "gasPrice": txGasPrice,
+            "value": txValue,
+            "nonce": nonce,
+            "accessList": accessList,
+            "chainId": chainId,
+            "typeInt": 30721,
+        }
+
+        method = "eth_signTransaction" # eth_signTransaction is supported
+        params = [transaction]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        rawData = result["raw"]
+
+        method = f"{self.ns}_sendRawTransactions"
+        params = [[rawData]]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        self.assertEqual(len(result), 1)
+        self.assertRegex(result[0], "^0x[0-9a-f]{64}$")
+
+    def test_kaia_sendRawTransactions_DynamicFee_error_kaia_signTransaction(self):
+        Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_chainId"
+        params = []
+        chainId, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(60400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441)
+        transaction = {
+            "from": txFrom,
+            "to": txTo,
+            "gas": txGas,
+            "maxPriorityFeePerGas": txGasPrice,
+            "maxFeePerGas": txGasPrice,
+            "value": txValue,
+            "nonce": nonce,
+            "accessList": [],
+            "chainId": chainId,
+            "typeInt": 30722,
+        }
+
+        method = "kaia_signTransaction" # kaia_signTransaction is not supported
+        params = [transaction]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        rawData = result["raw"]
+
+        method = f"{self.ns}_sendRawTransactions"
+        params = [[rawData]]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNotNone(error)
+        self.assertTrue("undefined tx type" in error["message"])
+        self.assertIsNone(result)
+
+    def test_kaia_sendRawTransactions_DynamicFee_success_eth_signTransaction(self):
+        Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_chainId"
+        params = []
+        chainId, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(60400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441)
+        transaction = {
+            "from": txFrom,
+            "to": txTo,
+            "gas": txGas,
+            "maxPriorityFeePerGas": txGasPrice,
+            "maxFeePerGas": txGasPrice,
+            "value": txValue,
+            "nonce": nonce,
+            "accessList": [],
+            "chainId": chainId,
+            "typeInt": 30722,
+        }
+
+        method = "eth_signTransaction" # eth_signTransaction is supported
+        params = [transaction]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        rawData = result["raw"]
+        method = f"{self.ns}_sendRawTransactions"
+        params = [[rawData]]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        self.assertEqual(len(result), 1)
+        self.assertRegex(result[0], "^0x[0-9a-f]{64}$")
+
+    def test_kaia_sendRawTransactions_SetCode_error_kaia_signTransaction(self):
+        Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_chainId"
+        params = []
+        chainId, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(90600)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441)
+        authorizationList = [
+            {
+                "chainId": "0x0",
+                "address": "0x000000000000000000000000000000000000aaaa",
+                "nonce": "0x0",
+                "yParity": "0x1",
+                "r": "0x79eae4cbf85eae84eac1311d7384f4f3bca88078cde0dbf0203248b074b7c36d",
+                "s": "0x8ea1adf9dded4d8223bd6784a6bf711211b381f04a34e9bea39e3ea81213d32",
+            },
+            {
+                "chainId": "0x0",
+                "address": "0x000000000000000000000000000000000000bbbb",
+                "nonce": "0x1",
+                "yParity": "0x1",
+                "r": "0x79eae4cbf85eae84eac1311d7384f4f3bca88078cde0dbf0203248b074b7c36d",
+                "s": "0x8ea1adf9dded4d8223bd6784a6bf711211b381f04a34e9bea39e3ea81213d32",
+            },
+        ]
+        transaction = {
+            "from": txFrom,
+            "to": txTo,
+            "gas": txGas,
+            "maxPriorityFeePerGas": txGasPrice,
+            "maxFeePerGas": txGasPrice,
+            "value": txValue,
+            "nonce": nonce,
+            "accessList": [],
+            "authorizationList": authorizationList,
+            "chainId": chainId,
+            "typeInt": 30724, # Type4
+        }
+
+        method = "kaia_signTransaction" # kaia_signTransaction is not supported
+        params = [transaction]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        rawData = result["raw"]
+        method = f"{self.ns}_sendRawTransactions"
+        params = [[rawData]]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNotNone(error)
+        self.assertTrue("undefined tx type" in error["message"])
+        self.assertIsNone(result)
+
+    def test_kaia_sendRawTransactions_SetCode_success_eth_signTransaction(self):
+        Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_chainId"
+        params = []
+        chainId, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(90600)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441)
+        authorizationList = [
+            {
+                "chainId": "0x0",
+                "address": "0x000000000000000000000000000000000000aaaa",
+                "nonce": "0x0",
+                "yParity": "0x1",
+                "r": "0x79eae4cbf85eae84eac1311d7384f4f3bca88078cde0dbf0203248b074b7c36d",
+                "s": "0x8ea1adf9dded4d8223bd6784a6bf711211b381f04a34e9bea39e3ea81213d32",
+            },
+            {
+                "chainId": "0x0",
+                "address": "0x000000000000000000000000000000000000bbbb",
+                "nonce": "0x1",
+                "yParity": "0x1",
+                "r": "0x79eae4cbf85eae84eac1311d7384f4f3bca88078cde0dbf0203248b074b7c36d",
+                "s": "0x8ea1adf9dded4d8223bd6784a6bf711211b381f04a34e9bea39e3ea81213d32",
+            },
+        ]
+        transaction = {
+            "from": txFrom,
+            "to": txTo,
+            "gas": txGas,
+            "maxPriorityFeePerGas": txGasPrice,
+            "maxFeePerGas": txGasPrice,
+            "value": txValue,
+            "nonce": nonce,
+            "accessList": [],
+            "authorizationList": authorizationList,
+            "chainId": chainId,
+            "typeInt": 30724, # Type4
+        }
+
+        method = "eth_signTransaction" # eth_signTransaction is supported
+        params = [transaction]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        rawData = result["raw"]
+        method = f"{self.ns}_sendRawTransactions"
+        params = [[rawData]]
+        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        self.assertEqual(len(result), 1)
+        self.assertRegex(result[0], "^0x[0-9a-f]{64}$")
+
     @staticmethod
     def suite():
         suite = unittest.TestSuite()
@@ -1965,4 +2344,14 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
             TestKaiaNamespaceTransactionRPC("test_kaia_getTransactionReceiptBySenderTxHash_success_wrong_value_param")
         )
         suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_getTransactionReceiptBySenderTxHash_success"))
+
+        suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_sendRawTransactions_error_no_param"))
+        suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_sendRawTransactions_error_wrong_type_param"))
+        suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_sendRawTransactions_success"))
+        suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_sendRawTransactions_AccessList_error_kaia_signTransaction"))
+        suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_sendRawTransactions_AccessList_success_eth_signTransaction"))
+        suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_sendRawTransactions_DynamicFee_error_kaia_signTransaction"))
+        suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_sendRawTransactions_DynamicFee_success_eth_signTransaction"))
+        suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_sendRawTransactions_SetCode_error_kaia_signTransaction"))
+        suite.addTest(TestKaiaNamespaceTransactionRPC("test_kaia_sendRawTransactions_SetCode_success_eth_signTransaction"))
         return suite

--- a/kaia/transaction/kaia_transaction_ws.py
+++ b/kaia/transaction/kaia_transaction_ws.py
@@ -1601,7 +1601,7 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         ]
         _, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         #Utils.check_error(self, "GasRequiredExceedsAllowance", error)
-        self.assertIsNone(error) # The way "arg.Gas" is handled is different
+        self.assertIsNone(error) # "arg.Gas" is handled differently
 
     def test_kaia_estimateGas_error_evm_revert_message(self):
         method = f"{self.ns}_estimateGas"

--- a/kaia/transaction/kaia_transaction_ws.py
+++ b/kaia/transaction/kaia_transaction_ws.py
@@ -914,6 +914,124 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         txHash, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
 
+    def test_kaia_sendRawTransaction_SetCode_error_wrong_prefix(self):
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_chainID"
+        params = []
+        chainId, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(60400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441)
+        authorizationList = [
+            {
+                "chainId": "0x0",
+                "address": "0x000000000000000000000000000000000000aaaa",
+                "nonce": "0x0",
+                "yParity": "0x1",
+                "r": "0x79eae4cbf85eae84eac1311d7384f4f3bca88078cde0dbf0203248b074b7c36d",
+                "s": "0x8ea1adf9dded4d8223bd6784a6bf711211b381f04a34e9bea39e3ea81213d32",
+            },
+        ]
+        transaction = {
+            "from": txFrom,
+            "to": txTo,
+            "gas": txGas,
+            "maxPriorityFeePerGas": txGasPrice,
+            "maxFeePerGas": txGasPrice,
+            "value": txValue,
+            "nonce": nonce,
+            "accessList": [],
+            "authorizationList": authorizationList,
+            "chainId": chainId,
+            "typeInt": 30724, # Type4
+        }
+
+        method = f"{self.ns}_signTransaction"
+        params = [transaction]
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        rawData = result["raw"]
+        rawTxWithoutHexPrefix = rawData[6:]
+
+        testSize = 300
+        for i in range(0, testSize):
+            randomPrefix = hex(random.randint(81, 30720))
+            if len(randomPrefix) % 2 == 1:
+                randomPrefix = f"0x0{randomPrefix[2:]}"
+            rawTx = randomPrefix + rawTxWithoutHexPrefix
+            method = f"{self.ns}_sendRawTransaction"
+            params = [rawTx]
+            result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+            self.assertIsNotNone(error)
+            self.assertTrue("undefined tx type" in error["message"] or "rlp:" in error["message"])
+
+    def test_kaia_sendRawTransaction_SetCode_success(self):
+        Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_chainID"
+        params = []
+        chainId, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(60400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441)
+        authorizationList = [
+            {
+                "chainId": "0x0",
+                "address": "0x000000000000000000000000000000000000aaaa",
+                "nonce": "0x0",
+                "yParity": "0x1",
+                "r": "0x79eae4cbf85eae84eac1311d7384f4f3bca88078cde0dbf0203248b074b7c36d",
+                "s": "0x8ea1adf9dded4d8223bd6784a6bf711211b381f04a34e9bea39e3ea81213d32",
+            },
+        ]
+        transaction = {
+            "from": txFrom,
+            "to": txTo,
+            "gas": txGas,
+            "maxPriorityFeePerGas": txGasPrice,
+            "maxFeePerGas": txGasPrice,
+            "value": txValue,
+            "nonce": nonce,
+            "accessList": [],
+            "authorizationList": authorizationList,
+            "chainId": chainId,
+            "typeInt": 30724, # Type4
+        }
+
+        method = f"{self.ns}_signTransaction"
+        params = [transaction]
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        rawData = result["raw"]
+        method = f"{self.ns}_sendRawTransaction"
+        params = [rawData]
+        txHash, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
     def test_kaia_getTransactionByBlockHashAndIndex_error_no_param(self):
         method = f"{self.ns}_getTransactionByBlockHashAndIndex"
 
@@ -1762,6 +1880,7 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_signTransaction_error_wrong_type_param6"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_signTransaction_error_wrong_value_param"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_signTransaction_success"))
+
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_sendRawTransaction_error_no_param"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_sendRawTransaction_error_wrong_type_param"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_sendRawTransaction_success"))
@@ -1770,6 +1889,9 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_createAccessList_success"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_sendRawTransaction_DynamicFee_error_wrong_prefix"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_sendRawTransaction_DynamicFee_success"))
+        suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_sendRawTransaction_SetCode_error_wrong_prefix"))
+        suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_sendRawTransaction_SetCode_success"))
+
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_getTransactionByBlockHashAndIndex_error_no_param"))
         suite.addTest(
             TestKaiaNamespaceTransactionWS("test_kaia_getTransactionByBlockHashAndIndex_error_wrong_type_param")

--- a/kaia/transaction/kaia_transaction_ws.py
+++ b/kaia/transaction/kaia_transaction_ws.py
@@ -648,15 +648,18 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         params = []
         result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         Utils.check_error(self, "arg0NoParams", error)
+        self.assertIsNone(result)
 
     def test_kaia_sendRawTransaction_error_wrong_type_param(self):
         method = f"{self.ns}_sendRawTransaction"
         params = ["abcd"]
         result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         Utils.check_error(self, "arg0HexToBytes", error)
+        self.assertIsNone(result)
 
     def test_kaia_sendRawTransaction_success(self):
         Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
+
         method = f"{self.ns}_getTransactionCount"
         tag = "latest"
         txFrom = test_data_set["account"]["sender"]["address"]
@@ -683,12 +686,13 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         ]
         result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
-
         rawData = result["raw"]
+
         method = f"{self.ns}_sendRawTransaction"
         params = [rawData]
         result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
+        self.assertRegex(result, "^0x[0-9a-f]{64}$")
 
     def test_kaia_sendRawTransaction_AccessList_error_wrong_prefix(self):
         method = f"{self.ns}_getTransactionCount"
@@ -699,7 +703,7 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         nonce, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
 
-        method = f"{self.ns}_chainID"
+        method = f"{self.ns}_chainId"
         params = []
         chainId, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
@@ -736,6 +740,8 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
 
         testSize = 300
         for i in range(0, testSize):
+            # start=81: make bigger than TxTypeKaiaLast:80
+            # end=30720: make smaller than EthereumTxTypeEnvelope:"0x78"+"00"=0x7800
             randomPrefix = hex(random.randint(81, 30720))
             if len(randomPrefix) % 2 == 1:
                 randomPrefix = f"0x0{randomPrefix[2:]}"
@@ -745,6 +751,7 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
             result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
             self.assertIsNotNone(error)
             self.assertTrue("undefined tx type" in error["message"] or "rlp:" in error["message"])
+            self.assertIsNone(result)
 
     def test_kaia_sendRawTransaction_AccessList_success(self):
         Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
@@ -756,7 +763,7 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         nonce, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
 
-        method = f"{self.ns}_chainID"
+        method = f"{self.ns}_chainId"
         params = []
         chainId, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
@@ -787,12 +794,13 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         params = [transaction]
         result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
+        rawData = result["raw"]
 
         method = f"{self.ns}_sendRawTransaction"
-        rawData = result["raw"]
         params = [rawData]
         result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
+        self.assertRegex(result, "^0x[0-9a-f]{64}$")
 
     def test_kaia_createAccessList_success(self):
         method = f"{self.ns}_createAccessList"
@@ -817,7 +825,7 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         nonce, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
 
-        method = f"{self.ns}_chainID"
+        method = f"{self.ns}_chainId"
         params = []
         chainId, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
@@ -827,11 +835,6 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         txGas = hex(60400)
         txGasPrice = test_data_set["unitGasPrice"]
         txValue = hex(2441)
-        storageKeys = [
-            "0x0000000000000000000000000000000000000000000000000000000000000003",
-            "0x0000000000000000000000000000000000000000000000000000000000000007",
-        ]
-        accessList = [{"address": txFrom, "storageKeys": storageKeys}]
         transaction = {
             "from": txFrom,
             "to": txTo,
@@ -840,7 +843,7 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
             "maxFeePerGas": txGasPrice,
             "value": txValue,
             "nonce": nonce,
-            "accessList": accessList,
+            "accessList": [],
             "chainId": chainId,
             "typeInt": 30722,
         }
@@ -855,6 +858,8 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
 
         testSize = 300
         for i in range(0, testSize):
+            # start=81: make bigger than TxTypeKaiaLast:80
+            # end=30720: make smaller than EthereumTxTypeEnvelope:"0x78"+"00"=0x7800
             randomPrefix = hex(random.randint(81, 30720))
             if len(randomPrefix) % 2 == 1:
                 randomPrefix = f"0x0{randomPrefix[2:]}"
@@ -864,6 +869,7 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
             result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
             self.assertIsNotNone(error)
             self.assertTrue("undefined tx type" in error["message"] or "rlp:" in error["message"])
+            self.assertIsNone(result)
 
     def test_kaia_sendRawTransaction_DynamicFee_success(self):
         Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
@@ -875,7 +881,7 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         nonce, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
 
-        method = f"{self.ns}_chainID"
+        method = f"{self.ns}_chainId"
         params = []
         chainId, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
@@ -885,11 +891,6 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         txGas = hex(60400)
         txGasPrice = test_data_set["unitGasPrice"]
         txValue = hex(2441)
-        storageKeys = [
-            "0x0000000000000000000000000000000000000000000000000000000000000003",
-            "0x0000000000000000000000000000000000000000000000000000000000000007",
-        ]
-        accessList = [{"address": txFrom, "storageKeys": storageKeys}]
         transaction = {
             "from": txFrom,
             "to": txTo,
@@ -898,7 +899,7 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
             "maxFeePerGas": txGasPrice,
             "value": txValue,
             "nonce": nonce,
-            "accessList": accessList,
+            "accessList": [],
             "chainId": chainId,
             "typeInt": 30722,
         }
@@ -907,12 +908,13 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         params = [transaction]
         result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
-
         rawData = result["raw"]
+
         method = f"{self.ns}_sendRawTransaction"
         params = [rawData]
-        txHash, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
+        self.assertRegex(result, "^0x[0-9a-f]{64}$")
 
     def test_kaia_sendRawTransaction_SetCode_error_wrong_prefix(self):
         method = f"{self.ns}_getTransactionCount"
@@ -923,7 +925,7 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         nonce, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
 
-        method = f"{self.ns}_chainID"
+        method = f"{self.ns}_chainId"
         params = []
         chainId, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
@@ -967,6 +969,8 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
 
         testSize = 300
         for i in range(0, testSize):
+            # start=81: make bigger than TxTypeKaiaLast:80
+            # end=30720: make smaller than EthereumTxTypeEnvelope:"0x78"+"00"=0x7800
             randomPrefix = hex(random.randint(81, 30720))
             if len(randomPrefix) % 2 == 1:
                 randomPrefix = f"0x0{randomPrefix[2:]}"
@@ -976,6 +980,7 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
             result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
             self.assertIsNotNone(error)
             self.assertTrue("undefined tx type" in error["message"] or "rlp:" in error["message"])
+            self.assertIsNone(result)
 
     def test_kaia_sendRawTransaction_SetCode_success(self):
         Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
@@ -987,7 +992,7 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         nonce, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
 
-        method = f"{self.ns}_chainID"
+        method = f"{self.ns}_chainId"
         params = []
         chainId, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
@@ -1025,12 +1030,13 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         params = [transaction]
         result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
-
         rawData = result["raw"]
+
         method = f"{self.ns}_sendRawTransaction"
         params = [rawData]
-        txHash, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
+        self.assertRegex(result, "^0x[0-9a-f]{64}$")
 
     def test_kaia_getTransactionByBlockHashAndIndex_error_no_param(self):
         method = f"{self.ns}_getTransactionByBlockHashAndIndex"
@@ -1844,6 +1850,379 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         _, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
 
+    def test_kaia_sendRawTransactions_error_no_param(self):
+        method = f"{self.ns}_sendRawTransactions"
+        params = []
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        Utils.check_error(self, "arg0NoParams", error)
+        self.assertIsNone(result)
+
+    def test_kaia_sendRawTransactions_error_wrong_type_param(self):
+        method = f"{self.ns}_sendRawTransactions"
+        params = [["abcd"]]
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        Utils.check_error(self, "arg0HexToBytes", error)
+        self.assertIsNone(result)
+
+    def test_kaia_sendRawTransactions_success(self):
+        Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441406250)
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_signTransaction"
+        params = [
+            {
+                "from": txFrom,
+                "to": txTo,
+                "gas": txGas,
+                "gasPrice": txGasPrice,
+                "value": txValue,
+                "nonce": nonce,
+            }
+        ]
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        rawData = result["raw"]
+
+        method = f"{self.ns}_sendRawTransactions"
+        params = [[rawData]]
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        self.assertEqual(len(result), 1)
+        self.assertRegex(result[0], "^0x[0-9a-f]{64}$")
+
+    def test_kaia_sendRawTransactions_AccessList_error_kaia_signTransaction(self):
+        Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_chainId"
+        params = []
+        chainId, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441)
+        storageKeys = [
+            "0x0000000000000000000000000000000000000000000000000000000000000003",
+            "0x0000000000000000000000000000000000000000000000000000000000000007",
+        ]
+        accessList = [{"address": txFrom, "storageKeys": storageKeys}]
+        transaction = {
+            "from": txFrom,
+            "to": txTo,
+            "gas": txGas,
+            "gasPrice": txGasPrice,
+            "value": txValue,
+            "nonce": nonce,
+            "accessList": accessList,
+            "chainId": chainId,
+            "typeInt": 30721,
+        }
+
+        method = "kaia_signTransaction" # kaia_signTransaction is not supported
+        params = [transaction]
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        rawData = result["raw"]
+
+        method = f"{self.ns}_sendRawTransactions"
+        params = [[rawData]]
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNotNone(error)
+        self.assertTrue("undefined tx type" in error["message"])
+        self.assertIsNone(result)
+
+    def test_kaia_sendRawTransactions_AccessList_success_eth_signTransaction(self):
+        Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_chainId"
+        params = []
+        chainId, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441)
+        storageKeys = [
+            "0x0000000000000000000000000000000000000000000000000000000000000003",
+            "0x0000000000000000000000000000000000000000000000000000000000000007",
+        ]
+        accessList = [{"address": txFrom, "storageKeys": storageKeys}]
+        transaction = {
+            "from": txFrom,
+            "to": txTo,
+            "gas": txGas,
+            "gasPrice": txGasPrice,
+            "value": txValue,
+            "nonce": nonce,
+            "accessList": accessList,
+            "chainId": chainId,
+            "typeInt": 30721,
+        }
+
+        method = "eth_signTransaction" # eth_signTransaction is supported
+        params = [transaction]
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        rawData = result["raw"]
+
+        method = f"{self.ns}_sendRawTransactions"
+        params = [[rawData]]
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        self.assertEqual(len(result), 1)
+        self.assertRegex(result[0], "^0x[0-9a-f]{64}$")
+
+    def test_kaia_sendRawTransactions_DynamicFee_error_kaia_signTransaction(self):
+        Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_chainId"
+        params = []
+        chainId, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(60400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441)
+        transaction = {
+            "from": txFrom,
+            "to": txTo,
+            "gas": txGas,
+            "maxPriorityFeePerGas": txGasPrice,
+            "maxFeePerGas": txGasPrice,
+            "value": txValue,
+            "nonce": nonce,
+            "accessList": [],
+            "chainId": chainId,
+            "typeInt": 30722,
+        }
+
+        method = "kaia_signTransaction" # kaia_signTransaction is not supported
+        params = [transaction]
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        rawData = result["raw"]
+
+        method = f"{self.ns}_sendRawTransactions"
+        params = [[rawData]]
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNotNone(error)
+        self.assertTrue("undefined tx type" in error["message"])
+        self.assertIsNone(result)
+
+    def test_kaia_sendRawTransactions_DynamicFee_success_eth_signTransaction(self):
+        Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_chainId"
+        params = []
+        chainId, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(60400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441)
+        transaction = {
+            "from": txFrom,
+            "to": txTo,
+            "gas": txGas,
+            "maxPriorityFeePerGas": txGasPrice,
+            "maxFeePerGas": txGasPrice,
+            "value": txValue,
+            "nonce": nonce,
+            "accessList": [],
+            "chainId": chainId,
+            "typeInt": 30722,
+        }
+
+        method = "eth_signTransaction" # eth_signTransaction is supported
+        params = [transaction]
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        rawData = result["raw"]
+        method = f"{self.ns}_sendRawTransactions"
+        params = [[rawData]]
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        self.assertEqual(len(result), 1)
+        self.assertRegex(result[0], "^0x[0-9a-f]{64}$")
+
+    def test_kaia_sendRawTransactions_SetCode_error_kaia_signTransaction(self):
+        Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_chainId"
+        params = []
+        chainId, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(90600)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441)
+        authorizationList = [
+            {
+                "chainId": "0x0",
+                "address": "0x000000000000000000000000000000000000aaaa",
+                "nonce": "0x0",
+                "yParity": "0x1",
+                "r": "0x79eae4cbf85eae84eac1311d7384f4f3bca88078cde0dbf0203248b074b7c36d",
+                "s": "0x8ea1adf9dded4d8223bd6784a6bf711211b381f04a34e9bea39e3ea81213d32",
+            },
+            {
+                "chainId": "0x0",
+                "address": "0x000000000000000000000000000000000000bbbb",
+                "nonce": "0x1",
+                "yParity": "0x1",
+                "r": "0x79eae4cbf85eae84eac1311d7384f4f3bca88078cde0dbf0203248b074b7c36d",
+                "s": "0x8ea1adf9dded4d8223bd6784a6bf711211b381f04a34e9bea39e3ea81213d32",
+            },
+        ]
+        transaction = {
+            "from": txFrom,
+            "to": txTo,
+            "gas": txGas,
+            "maxPriorityFeePerGas": txGasPrice,
+            "maxFeePerGas": txGasPrice,
+            "value": txValue,
+            "nonce": nonce,
+            "accessList": [],
+            "authorizationList": authorizationList,
+            "chainId": chainId,
+            "typeInt": 30724, # Type4
+        }
+
+        method = "kaia_signTransaction" # kaia_signTransaction is not supported
+        params = [transaction]
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        rawData = result["raw"]
+        method = f"{self.ns}_sendRawTransactions"
+        params = [[rawData]]
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNotNone(error)
+        self.assertTrue("undefined tx type" in error["message"])
+        self.assertIsNone(result)
+
+    def test_kaia_sendRawTransactions_SetCode_success_eth_signTransaction(self):
+        Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
+        method = f"{self.ns}_getTransactionCount"
+        tag = "latest"
+        txFrom = test_data_set["account"]["sender"]["address"]
+
+        params = [txFrom, tag]
+        nonce, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        method = f"{self.ns}_chainId"
+        params = []
+        chainId, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        password = test_data_set["account"]["sender"]["password"]
+        txTo = test_data_set["account"]["sender"]["address"]
+        txGas = hex(90600)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(2441)
+        authorizationList = [
+            {
+                "chainId": "0x0",
+                "address": "0x000000000000000000000000000000000000aaaa",
+                "nonce": "0x0",
+                "yParity": "0x1",
+                "r": "0x79eae4cbf85eae84eac1311d7384f4f3bca88078cde0dbf0203248b074b7c36d",
+                "s": "0x8ea1adf9dded4d8223bd6784a6bf711211b381f04a34e9bea39e3ea81213d32",
+            },
+            {
+                "chainId": "0x0",
+                "address": "0x000000000000000000000000000000000000bbbb",
+                "nonce": "0x1",
+                "yParity": "0x1",
+                "r": "0x79eae4cbf85eae84eac1311d7384f4f3bca88078cde0dbf0203248b074b7c36d",
+                "s": "0x8ea1adf9dded4d8223bd6784a6bf711211b381f04a34e9bea39e3ea81213d32",
+            },
+        ]
+        transaction = {
+            "from": txFrom,
+            "to": txTo,
+            "gas": txGas,
+            "maxPriorityFeePerGas": txGasPrice,
+            "maxFeePerGas": txGasPrice,
+            "value": txValue,
+            "nonce": nonce,
+            "accessList": [],
+            "authorizationList": authorizationList,
+            "chainId": chainId,
+            "typeInt": 30724, # Type4
+        }
+
+        method = "eth_signTransaction" # eth_signTransaction is supported
+        params = [transaction]
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+        rawData = result["raw"]
+        method = f"{self.ns}_sendRawTransactions"
+        params = [[rawData]]
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        self.assertEqual(len(result), 1)
+        self.assertRegex(result[0], "^0x[0-9a-f]{64}$")
+
     @staticmethod
     def suite():
         suite = unittest.TestSuite()
@@ -1965,4 +2344,14 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
             TestKaiaNamespaceTransactionWS("test_kaia_getTransactionReceiptBySenderTxHash_success_wrong_value_param")
         )
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_getTransactionReceiptBySenderTxHash_success"))
+
+        suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_sendRawTransactions_error_no_param"))
+        suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_sendRawTransactions_error_wrong_type_param"))
+        suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_sendRawTransactions_success"))
+        suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_sendRawTransactions_AccessList_error_kaia_signTransaction"))
+        suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_sendRawTransactions_AccessList_success_eth_signTransaction"))
+        suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_sendRawTransactions_DynamicFee_error_kaia_signTransaction"))
+        suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_sendRawTransactions_DynamicFee_success_eth_signTransaction"))
+        suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_sendRawTransactions_SetCode_error_kaia_signTransaction"))
+        suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_sendRawTransactions_SetCode_success_eth_signTransaction"))
         return suite

--- a/kaia/transaction/kaia_transaction_ws.py
+++ b/kaia/transaction/kaia_transaction_ws.py
@@ -1,6 +1,5 @@
 import unittest
 import random
-from unittest import result
 from utils import Utils
 from common import kaia as kaia_common
 
@@ -1426,7 +1425,22 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         _, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         Utils.check_error(self, "arg0StringToCallArgsDataBytes", error)
 
-    def test_kaia_estimateGas_error_exceeds_allowance(self):
+    def test_kaia_estimateGas_error_insufficient_balance(self):
+        method = f"{self.ns}_estimateGas"
+        zeroBalanceAddr = "0x15318f21f3dee6b2c64d2a633cb8c1194877c882"
+        txValue = hex(1)
+        params = [
+            {
+                "from": zeroBalanceAddr,
+                "to": zeroBalanceAddr,
+                "value": txValue,
+            },
+            "latest",
+        ]
+        _, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        Utils.check_error(self, "InsufficientBalance", error)
+
+    def test_kaia_estimateGas_error_insufficient_funds(self):
         method = f"{self.ns}_estimateGas"
         zeroBalanceAddr = "0x15318f21f3dee6b2c64d2a633cb8c1194877c882"
         contract = test_data_set["contracts"]["unknown"]["address"][0]
@@ -1445,21 +1459,42 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
             "latest",
         ]
         _, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
-        Utils.check_error(self, "GasRequiredExceedsAllowance", error)
+        Utils.check_error(self, "InsufficientFunds", error)
+
+    def test_kaia_estimateGas_error_exceeds_allowance(self):
+        method = f"{self.ns}_estimateGas"
+        address = test_data_set["account"]["1pebHolder"]["address"]
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(0)
+        params = [
+            {
+                "from": address,
+                "to": address,
+                "value": txValue,
+                "gasPrice": txGasPrice,
+            },
+            "latest",
+        ]
+        _, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        #Utils.check_error(self, "GasRequiredExceedsAllowance", error)
+        self.assertIsNone(error) # The way "arg.Gas" is handled is different
 
     def test_kaia_estimateGas_error_evm_revert_message(self):
         method = f"{self.ns}_estimateGas"
         ownerContract = test_data_set["contracts"]["unknown"]["address"][0]
         notOwner = "0x15318f21f3dee6b2c64d2a633cb8c1194877c882"
-        changeOwnerAbi = "0xa6f9dae10000000000000000000000003e2ac308cd78ac2fe162f9522deb2b56d9da9499"  # changeOwner("0x3e2ac308cd78ac2fe162f9522deb2b56d9da9499")
-        params = [{"from": notOwner, "to": ownerContract, "data": changeOwnerAbi}]
+        changeOwnerAbi = "0xa6f9dae10000000000000000000000003e2ac308cd78ac2fe162f9522deb2b56d9da9499" # changeOwner("0x3e2ac308cd78ac2fe162f9522deb2b56d9da9499")
+        params = [
+            {"from": notOwner, "to": ownerContract, "data": changeOwnerAbi},
+            "latest",
+        ]
         _, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         Utils.check_error(self, "ExecutionReverted", error)
 
     def test_kaia_estimateGas_error_revert(self):
         method = f"{self.ns}_estimateGas"
         contract = test_data_set["contracts"]["unknown"]["address"][0]
-        params = [{"to": contract}]
+        params = [{"to": contract}, "latest"]
         _, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         Utils.check_error(self, "ExecutionReverted", error)
 
@@ -1472,10 +1507,14 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         txGasPrice = test_data_set["unitGasPrice"]
         txValue = hex(0)
         params = [{"from": address, "to": contract, "value": txValue, "input": code}]
-        _, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
+        self.assertIsNotNone(result)
+        estimated_gas = int(result, 16)
+        expected_gas = 25841
+        self.assertEqual(estimated_gas, expected_gas)
 
-    def test_kaia_estimateGas_success_data_instead_input(self):
+    def test_kaia_estimateGas_success_data_for_backward_compatibility(self):
         method = f"{self.ns}_estimateGas"
         address = test_data_set["account"]["sender"]["address"]
         contract = test_data_set["contracts"]["unknown"]["address"][0]
@@ -1483,9 +1522,13 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         txGas = hex(30400)
         txGasPrice = test_data_set["unitGasPrice"]
         txValue = hex(0)
-        params = [{"from": address, "to": contract, "value": txValue, "data": code}]
-        _, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        params = [{"from": address, "to": contract, "value": txValue, "data": code}] # using data
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
+        self.assertIsNotNone(result)
+        estimated_gas = int(result, 16)
+        expected_gas = 25841
+        self.assertEqual(estimated_gas, expected_gas)
 
     def test_kaia_estimateGas_success_floor_data_gas(self):
         method = f"{self.ns}_estimateGas"
@@ -1493,11 +1536,28 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         contract = test_data_set["contracts"]["unknown"]["address"][0]
         large_calldata = test_data_set["contracts"]["unknown"]["input"] + "ff" * 1000  # Function call + 1KB of data
         params = [{"from": address, "to": contract, "data": large_calldata}]
-        result, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
         self.assertIsNone(error)
         self.assertIsNotNone(result)
         estimated_gas = int(result, 16)
         expected_gas = 61510
+        self.assertEqual(estimated_gas, expected_gas)
+
+    def test_kaia_estimateGas_success_state_override_balance_and_code(self):
+        method = f"{self.ns}_estimateGas"
+        address = test_data_set["account"]["sender"]["address"]
+        contract = test_data_set["contracts"]["unknown"]["address"][0]
+        code = test_data_set["contracts"]["unknown"]["input"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(0)
+        stateOverrides = {address: {"balance": hex(int(txGas, base=16) * int(txGasPrice, base=16))}}
+        params = [{"from": address, "to": contract, "value": txValue, "data": code}, "latest", stateOverrides]
+        result, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+        self.assertIsNotNone(result)
+        estimated_gas = int(result, 16)
+        expected_gas = 25841
         self.assertEqual(estimated_gas, expected_gas)
 
     def test_kaia_estimateComputationCost_success(self):
@@ -1749,14 +1809,21 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_call_success3"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_call_success4"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_call_success_input_instead_data"))
+
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_estimateGas_error_no_param"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_estimateGas_error_wrong_type_param1"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_estimateGas_error_wrong_type_param2"))
+        suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_estimateGas_error_insufficient_balance"))
+        suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_estimateGas_error_insufficient_funds"))
+        suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_estimateGas_error_exceeds_allowance"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_estimateGas_error_evm_revert_message"))
+        suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_estimateGas_error_revert"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_estimateGas_success"))
-        suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_estimateGas_success_data_instead_input"))
+        suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_estimateGas_success_data_for_backward_compatibility"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_estimateGas_success_floor_data_gas"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_estimateComputationCost_success"))
+
+        suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_estimateGas_success_state_override_balance_and_code"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_estimateComputationCost_success_input_instead_data"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_getTransactionByHash_error_no_param"))
         suite.addTest(TestKaiaNamespaceTransactionWS("test_kaia_getTransactionByHash_error_wrong_type_param"))


### PR DESCRIPTION
Improvements:
* related EIP-7702
  * kaia_getAccount
  * kaia_isContractAccount
  * eth/kaia_sendRawTransaction
* related supporting override feature
  * eth/kaia_estimateGas

Additions:
 * kaia_isConsoleLogEnabled
 * debug_isGaslessTx
 * debug_gaslessInfo
 * kaia_sendRawTransactions
