### PR TITLE
Fix to handle the changing of kaia#452

### DIFF
--- a/kaia/transaction/kaia_transaction_rpc.py
+++ b/kaia/transaction/kaia_transaction_rpc.py
@@ -1600,8 +1600,7 @@ class TestKaiaNamespaceTransactionRPC(unittest.TestCase):
             "latest",
         ]
         _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
-        #Utils.check_error(self, "GasRequiredExceedsAllowance", error)
-        self.assertIsNone(error) # "arg.Gas" is handled differently
+        Utils.check_error(self, "GasRequiredExceedsAllowance", error)
 
     def test_kaia_estimateGas_error_evm_revert_message(self):
         method = f"{self.ns}_estimateGas"

--- a/kaia/transaction/kaia_transaction_ws.py
+++ b/kaia/transaction/kaia_transaction_ws.py
@@ -1600,8 +1600,7 @@ class TestKaiaNamespaceTransactionWS(unittest.TestCase):
             "latest",
         ]
         _, error = Utils.call_ws(self.endpoint, method, params, self.log_path)
-        #Utils.check_error(self, "GasRequiredExceedsAllowance", error)
-        self.assertIsNone(error) # "arg.Gas" is handled differently
+        Utils.check_error(self, "GasRequiredExceedsAllowance", error)
 
     def test_kaia_estimateGas_error_evm_revert_message(self):
         method = f"{self.ns}_estimateGas"


### PR DESCRIPTION
Handle the changing of kaiachain/kaia#452
See: https://github.com/kaiachain/kaia-rpc-tester/pull/12#issuecomment-3055000360

Both are the same behavior
* (rpc/ws) test_eth_estimateGas_error_exceeds_allowance
* (rpc/ws) test_kaia_estimateGas_error_exceeds_allowance
