### PR TITLE
Add test coverage for Auction API (submitBid validation only)

### DIFF
--- a/config_template.json
+++ b/config_template.json
@@ -12,5 +12,5 @@
     "eoaWithCodePrivateKey": "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291",
     "eoaWithCodeAddress": "0x71562b71999873DB5b286dF957af199Ec94617F7",
     "eoaWithCodePassword": "2523",
-    "namespaces": "admin,debug,eth,governance,kaia,net,personal,txpool"
+    "namespaces": "admin,debug,eth,governance,kaia,net,personal,txpool,auction"
 }

--- a/errors.py
+++ b/errors.py
@@ -123,8 +123,10 @@ errors_json = """
     "RlpExceed": [-32000, "rlp: value size exceeds available input length"],
     "PendingLogsNotSupported": [-32000, "pending logs are not supported"],
     "NotificationsNotSupported": [-32000, "notifications not supported"],
-    "InvalidSubscriptionName": [-32602, "expected subscription name as first argument"]
-
+    "InvalidSubscriptionName": [-32602, "expected subscription name as first argument"],
+    "arg0InvalidBidParams": [-32602, "invalid argument 0: json: cannot unmarshal string into Go value of type impl.BidInput"],
+    "TooManyArguments": [-32602, "too many arguments, want at most 1"],
+    "arg1InvalidAddress": [-32602, "invalid argument 1: invalid address: invalid hex string"]
 }
 """
 

--- a/kaia/auction/kaia_auction_rpc.py
+++ b/kaia/auction/kaia_auction_rpc.py
@@ -1,0 +1,547 @@
+import unittest
+
+from utils import Utils
+
+# test_data_set is injected by rpc-tester/main.py
+global test_data_set
+
+
+class TestKaiaNamespaceAuctionRPC(unittest.TestCase):
+    config = Utils.get_config()
+    _, _, log_path = Utils.get_log_filename_with_path()
+    endpoint = config.get("endpoint")
+    rpc_port = config.get("rpcPort")
+    ws_port = config.get("wsPort")
+    ns = "auction"
+    waiting_count = 2
+
+    def test_auction_submitBid_error_no_param(self):
+        method = f"{self.ns}_submitBid"
+        _, error = Utils.call_rpc(self.endpoint, method, [], self.log_path)
+        Utils.check_error(self, "arg0NoParams", error)
+
+    def test_auction_submitBid_error_wrong_type_param(self):
+        method = f"{self.ns}_submitBid"
+        _, error = Utils.call_rpc(self.endpoint, method, [
+                                  "invalid_param"], self.log_path)
+        Utils.check_error(self, "arg0InvalidBidParams", error)
+
+    def test_auction_submitBid_error_empty_target_tx_raw(self):
+        method = f"{self.ns}_submitBid"
+        bid_input = {
+            "targetTxRaw": "",
+            "targetTxHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "blockNumber": 0,
+            "sender": "0x0000000000000000000000000000000000000000",
+            "to": "0x0000000000000000000000000000000000000000",
+            "nonce": 0,
+            "bid": "0x0",
+            "callGasLimit": 0,
+            "data": "0x",
+            "searcherSig": "0x",
+            "auctioneerSig": "0x"
+        }
+        result, error = Utils.call_rpc(self.endpoint, method, [
+                                       bid_input], self.log_path)
+        self.assertIsNone(error)
+        self.assertIsNotNone(result)
+        self.assertIn("err", result)
+        self.assertEqual(result["err"], "Empty target tx raw")
+
+    def test_auction_submitBid_error_invalid_target_tx_raw(self):
+        method = f"{self.ns}_submitBid"
+        bid_input = {
+            "targetTxRaw": "0xinvalid",
+            "targetTxHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "blockNumber": 0,
+            "sender": "0x0000000000000000000000000000000000000000",
+            "to": "0x0000000000000000000000000000000000000000",
+            "nonce": 0,
+            "bid": "0x0",
+            "callGasLimit": 0,
+            "data": "0x",
+            "searcherSig": "0x",
+            "auctioneerSig": "0x"
+        }
+        _, error = Utils.call_rpc(self.endpoint, method, [
+                                  bid_input], self.log_path)
+        self.assertIsNotNone(error)
+
+    def test_auction_submitBid_error_invalid_target_tx_hash(self):
+        method = f"{self.ns}_submitBid"
+        bid_input = {
+            "targetTxRaw": "0x",
+            "targetTxHash": "0xinvalid",
+            "blockNumber": 0,
+            "sender": "0x0000000000000000000000000000000000000000",
+            "to": "0x0000000000000000000000000000000000000000",
+            "nonce": 0,
+            "bid": "0x0",
+            "callGasLimit": 0,
+            "data": "0x",
+            "searcherSig": "0x",
+            "auctioneerSig": "0x"
+        }
+        _, error = Utils.call_rpc(self.endpoint, method, [
+                                  bid_input], self.log_path)
+        self.assertIsNotNone(error)
+
+    def test_auction_submitBid_error_invalid_sender_address(self):
+        method = f"{self.ns}_submitBid"
+        bid_input = {
+            "targetTxRaw": "0x",
+            "targetTxHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "blockNumber": 0,
+            "sender": "0xinvalid",
+            "to": "0x0000000000000000000000000000000000000000",
+            "nonce": 0,
+            "bid": "0x0",
+            "callGasLimit": 0,
+            "data": "0x",
+            "searcherSig": "0x",
+            "auctioneerSig": "0x"
+        }
+        _, error = Utils.call_rpc(self.endpoint, method, [
+                                  bid_input], self.log_path)
+        self.assertIsNotNone(error)
+
+    def test_auction_submitBid_error_invalid_to_address(self):
+        method = f"{self.ns}_submitBid"
+        bid_input = {
+            "targetTxRaw": "0x",
+            "targetTxHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "blockNumber": 0,
+            "sender": "0x0000000000000000000000000000000000000000",
+            "to": "0xinvalid",
+            "nonce": 0,
+            "bid": "0x0",
+            "callGasLimit": 0,
+            "data": "0x",
+            "searcherSig": "0x",
+            "auctioneerSig": "0x"
+        }
+        _, error = Utils.call_rpc(self.endpoint, method, [
+                                  bid_input], self.log_path)
+        self.assertIsNotNone(error)
+
+    def test_auction_submitBid_error_wrong_field_types(self):
+        method = f"{self.ns}_submitBid"
+        bid_input = {
+            "targetTxRaw": 123,  # Should be string
+            "targetTxHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "blockNumber": "invalid",  # Should be number
+            "sender": "0x0000000000000000000000000000000000000000",
+            "to": "0x0000000000000000000000000000000000000000",
+            "nonce": "invalid",  # Should be number
+            "bid": "0x3",
+            "callGasLimit": "invalid",  # Should be number
+            "data": "0x",
+            "searcherSig": "0x",
+            "auctioneerSig": "0x"
+        }
+        _, error = Utils.call_rpc(self.endpoint, method, [
+                                  bid_input], self.log_path)
+        self.assertIsNotNone(error)
+
+    def test_auction_call_error_no_param1(self):
+        method = f"{self.ns}_call"
+        params = []
+        _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        Utils.check_error(self, "arg0NoParams", error)
+
+    def test_auction_call_error_no_param2(self):
+        method = f"{self.ns}_call"
+        contract = test_data_set["contracts"]["unknown"]["address"][0]
+        params = [{"to": contract}, "latest"]
+        _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        Utils.check_error(self, "ExecutionReverted", error)
+
+    def test_auction_call_error_no_param3(self):
+        method = f"{self.ns}_call"
+        methodName = "auction_call"
+        address = test_data_set["account"]["sender"]["address"]
+        contract = test_data_set["contracts"]["unknown"]["address"][0]
+        code = test_data_set["contracts"]["unknown"]["input"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(0)
+        params = [{"data": code}, "latest"]
+        _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        Utils.check_error(self, "VMErrorOccurs", error)
+
+    def test_auction_call_error_wrong_type_param1(self):
+        method = f"{self.ns}_call"
+        address = test_data_set["account"]["sender"]["address"]
+        contract = test_data_set["contracts"]["unknown"]["address"][0]
+        code = test_data_set["contracts"]["unknown"]["input"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(0)
+        params = [
+            {
+                "from": 1234,
+                "to": contract,
+                "gas": txGas,
+                "gasPrice": txGasPrice,
+                "value": txValue,
+                "data": code,
+            },
+            "latest",
+        ]
+        _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        Utils.check_error(self, "arg0NonstringToCallArgsFromAddress", error)
+
+    def test_auction_call_error_wrong_type_param2(self):
+        method = f"{self.ns}_call"
+        address = test_data_set["account"]["sender"]["address"]
+        contract = test_data_set["contracts"]["unknown"]["address"][0]
+        code = test_data_set["contracts"]["unknown"]["input"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(0)
+        params = [
+            {
+                "from": address,
+                "to": 1234,
+                "gas": txGas,
+                "gasPrice": txGasPrice,
+                "value": txValue,
+                "data": code,
+            },
+            "latest",
+        ]
+        _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        Utils.check_error(self, "arg0NonstringToCallArgsToAddress", error)
+
+    def test_auction_call_error_wrong_type_param3(self):
+        method = f"{self.ns}_call"
+        address = test_data_set["account"]["sender"]["address"]
+        contract = test_data_set["contracts"]["unknown"]["address"][0]
+        code = test_data_set["contracts"]["unknown"]["input"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(0)
+        params = [
+            {
+                "from": address,
+                "to": contract,
+                "gas": "txGas",
+                "gasPrice": txGasPrice,
+                "value": txValue,
+                "data": code,
+            },
+            "latest",
+        ]
+        _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        Utils.check_error(self, "arg0HexToCallArgsGasUint64", error)
+
+    def test_auction_call_error_wrong_type_param4(self):
+        method = f"{self.ns}_call"
+        address = test_data_set["account"]["sender"]["address"]
+        contract = test_data_set["contracts"]["unknown"]["address"][0]
+        code = test_data_set["contracts"]["unknown"]["input"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(0)
+        params = [
+            {
+                "from": address,
+                "to": contract,
+                "gas": txGas,
+                "gasPrice": "txGasPrice",
+                "value": txValue,
+                "data": code,
+            },
+            "latest",
+        ]
+        _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        Utils.check_error(self, "arg0HexToCallArgsGaspriceBig", error)
+
+    def test_auction_call_error_wrong_type_param5(self):
+        method = f"{self.ns}_call"
+        address = test_data_set["account"]["sender"]["address"]
+        contract = test_data_set["contracts"]["unknown"]["address"][0]
+        code = test_data_set["contracts"]["unknown"]["input"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(0)
+        params = [
+            {
+                "from": address,
+                "to": contract,
+                "gas": txGas,
+                "gasPrice": txGasPrice,
+                "value": "txValue",
+                "data": code,
+            },
+            "latest",
+        ]
+        _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        Utils.check_error(self, "arg0HexToCallArgsValueBig", error)
+
+    def test_auction_call_error_wrong_type_param6(self):
+        method = f"{self.ns}_call"
+        address = test_data_set["account"]["sender"]["address"]
+        contract = test_data_set["contracts"]["unknown"]["address"][0]
+        code = test_data_set["contracts"]["unknown"]["input"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(0)
+        params = [
+            {
+                "from": address,
+                "to": contract,
+                "gas": txGas,
+                "gasPrice": txGasPrice,
+                "value": txValue,
+                "data": 1234,
+            },
+            "latest",
+        ]
+        _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        Utils.check_error(self, "arg0NonstringToCallArgsDataBytes", error)
+
+    def test_auction_call_error_wrong_type_param7(self):
+        method = f"{self.ns}_call"
+        address = test_data_set["account"]["sender"]["address"]
+        contract = test_data_set["contracts"]["unknown"]["address"][0]
+        code = test_data_set["contracts"]["unknown"]["input"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(0)
+        params = [
+            {
+                "from": address,
+                "to": contract,
+                "gas": txGas,
+                "gasPrice": txGasPrice,
+                "value": txValue,
+                "data": code,
+            },
+            "abcd",
+        ]
+        _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        Utils.check_error(self, "arg1HexWithoutPrefix", error)
+
+    def test_auction_call_error_wrong_value_param1(self):
+        method = f"{self.ns}_call"
+        address = test_data_set["account"]["sender"]["address"]
+        contract = test_data_set["contracts"]["unknown"]["address"][0]
+        code = test_data_set["contracts"]["unknown"]["input"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(100000000000000000000000000000000000000000)
+        params = [
+            {
+                "from": address,
+                "to": contract,
+                "gas": txGas,
+                "gasPrice": txGasPrice,
+                "value": txValue,
+                "data": code,
+            },
+            "latest",
+        ]
+        result, error = Utils.call_rpc(
+            self.endpoint, method, params, self.log_path)
+        Utils.check_error(self, "ExecutionReverted", error)
+
+    def test_auction_call_error_intrinsic_gas(self):
+        method = f"{self.ns}_call"
+        contract = test_data_set["contracts"]["unknown"]["address"][0]
+        zeroBalanceAddr = "0x15318f21f3dee6b2c64d2a633cb8c1194877c882"
+        code = test_data_set["contracts"]["unknown"]["input"]
+        txGasPrice = test_data_set["unitGasPrice"]
+        params = [
+            {
+                "from": zeroBalanceAddr,
+                "to": contract,
+                "data": code,
+                "gas": "0x99",
+                "gasPrice": txGasPrice,
+            },
+            "latest",
+        ]
+        _, error = Utils.call_rpc(
+            self.endpoint, method, params, self.log_path)
+        Utils.check_error(self, "GasTooLow", error)
+
+    def test_auction_call_error_evm_revert_message(self):
+        method = f"{self.ns}_call"
+        address = test_data_set["account"]["sender"]["address"]
+        ownerContract = test_data_set["contracts"]["unknown"]["address"][0]
+        notOwner = "0x15318f21f3dee6b2c64d2a633cb8c1194877c882"
+        changeOwnerAbi = "0xa6f9dae10000000000000000000000003e2ac308cd78ac2fe162f9522deb2b56d9da9499"
+        params = [
+            {"from": notOwner, "to": ownerContract, "data": changeOwnerAbi},
+            "latest",
+        ]
+        result, error = Utils.call_rpc(
+            self.endpoint, method, params, self.log_path)
+        Utils.check_error(self, "ExecutionReverted", error)
+
+    def test_auction_call_success1(self):
+        method = f"{self.ns}_call"
+        address = test_data_set["account"]["sender"]["address"]
+        contract = test_data_set["contracts"]["unknown"]["address"][0]
+        code = test_data_set["contracts"]["unknown"]["input"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        params = [{"to": contract, "data": code}, "latest"]
+        _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+    def test_auction_call_success2(self):
+        method = f"{self.ns}_call"
+        address = test_data_set["account"]["sender"]["address"]
+        contract = test_data_set["contracts"]["unknown"]["address"][0]
+        code = test_data_set["contracts"]["unknown"]["input"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        params = [{"from": address, "to": contract, "data": code}, "latest"]
+        _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+    def test_auction_call_success3(self):
+        method = f"{self.ns}_call"
+        address = test_data_set["account"]["sender"]["address"]
+        contract = test_data_set["contracts"]["unknown"]["address"][0]
+        code = test_data_set["contracts"]["unknown"]["input"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        params = [
+            {
+                "from": address,
+                "to": contract,
+                "gas": txGas,
+                "gasPrice": txGasPrice,
+                "data": code,
+            },
+            "latest",
+        ]
+        _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+    def test_auction_call_success4(self):
+        method = f"{self.ns}_call"
+        address = test_data_set["account"]["sender"]["address"]
+        contract = test_data_set["contracts"]["unknown"]["address"][0]
+        code = test_data_set["contracts"]["unknown"]["input"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        txValue = hex(0)
+        params = [
+            {
+                "from": address,
+                "to": contract,
+                "gas": txGas,
+                "gasPrice": txGasPrice,
+                "value": txValue,
+                "data": code,
+            },
+            "latest",
+        ]
+        _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+    def test_auction_call_success_input_instead_data(self):
+        method = f"{self.ns}_call"
+        address = test_data_set["account"]["sender"]["address"]
+        contract = test_data_set["contracts"]["unknown"]["address"][0]
+        code = test_data_set["contracts"]["unknown"]["input"]
+        txGas = hex(30400)
+        txGasPrice = test_data_set["unitGasPrice"]
+        params = [{"to": contract, "input": code}, "latest"]
+        _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        self.assertIsNone(error)
+
+    def test_auction_subscribe_newPendingTransactions_error_unsupported_rpc(self):
+        method = f"{self.ns}_subscribe"
+        params = ["newPendingTransactions"]
+        _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        Utils.check_error(self, "NotificationsNotSupported", error)
+
+    def test_auction_subscribe_newHeads_error_unsupported_rpc(self):
+        method = f"{self.ns}_subscribe"
+        params = ["newHeads"]
+        _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        Utils.check_error(self, "NotificationsNotSupported", error)
+
+    def test_auction_subscribe_logs_error_unsupported_rpc(self):
+        method = f"{self.ns}_subscribe"
+        filter_criteria = {"fromBlock": "latest"}
+        params = ["logs", filter_criteria]
+        _, error = Utils.call_rpc(self.endpoint, method, params, self.log_path)
+        Utils.check_error(self, "NotificationsNotSupported", error)
+
+    @staticmethod
+    def suite():
+        suite = unittest.TestSuite()
+
+        # submitBid tests
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_submitBid_error_no_param"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_submitBid_error_wrong_type_param"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_submitBid_error_empty_target_tx_raw"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_submitBid_error_invalid_target_tx_raw"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_submitBid_error_invalid_target_tx_hash"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_submitBid_error_invalid_sender_address"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_submitBid_error_invalid_to_address"))
+
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_submitBid_error_wrong_field_types"))
+
+        # call tests
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_call_error_no_param1"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_call_error_no_param2"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_call_error_no_param3"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_call_error_wrong_type_param1"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_call_error_wrong_type_param2"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_call_error_wrong_type_param3"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_call_error_wrong_type_param4"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_call_error_wrong_type_param5"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_call_error_wrong_type_param6"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_call_error_wrong_type_param7"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_call_error_wrong_value_param1"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_call_error_evm_revert_message"))
+
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_call_error_intrinsic_gas"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_call_success1"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_call_success2"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_call_success3"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_call_success4"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_call_success_input_instead_data"))
+
+        # subscribe tests
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_subscribe_newPendingTransactions_error_unsupported_rpc"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_subscribe_newHeads_error_unsupported_rpc"))
+        suite.addTest(TestKaiaNamespaceAuctionRPC(
+            "test_auction_subscribe_logs_error_unsupported_rpc"))
+
+        return suite

--- a/kaia/auction/kaia_auction_ws.py
+++ b/kaia/auction/kaia_auction_ws.py
@@ -1,0 +1,156 @@
+import unittest
+
+from utils import Utils
+
+# test_data_set is injected by rpc-tester/main.py
+global test_data_set
+
+
+class TestKaiaNamespaceAuctionWS(unittest.TestCase):
+    config = Utils.get_config()
+    _, _, log_path = Utils.get_log_filename_with_path()
+    endpoint = config.get("endpoint")
+    rpc_port = config.get("rpcPort")
+    ws_port = config.get("wsPort")
+    ns = "auction"
+    waiting_count = 2
+
+    def test_auction_subscribe_newPendingTransactions_error_invalid_param_type(self):
+        method = f"{self.ns}_subscribe"
+        _, error = Utils.call_ws(self.endpoint, method, [
+                                 "newPendingTransactions", "invalid"], self.log_path)
+        Utils.check_error(self, "arg1StringToBool", error)
+
+    def test_auction_subscribe_newPendingTransactions_success_no_param(self):
+        method = f"{self.ns}_subscribe"
+        result, error = Utils.call_ws(self.endpoint, method, [
+                                      "newPendingTransactions"], self.log_path)
+        self.assertIsNone(error)
+        self.assertIsNotNone(result)
+
+    def test_auction_subscribe_newPendingTransactions_success_with_full_tx_true(self):
+        method = f"{self.ns}_subscribe"
+        result, error = Utils.call_ws(self.endpoint, method, [
+                                      "newPendingTransactions", True], self.log_path)
+        self.assertIsNone(error)
+        self.assertIsNotNone(result)
+
+    def test_auction_subscribe_newPendingTransactions_success_with_full_tx_false(self):
+        method = f"{self.ns}_subscribe"
+        result, error = Utils.call_ws(self.endpoint, method, [
+                                      "newPendingTransactions", False], self.log_path)
+        self.assertIsNone(error)
+        self.assertIsNotNone(result)
+
+    def test_auction_subscribe_newHeads_error_with_params(self):
+        method = f"{self.ns}_subscribe"
+        _, error = Utils.call_ws(self.endpoint, method, [
+                                 "newHeads", "invalid"], self.log_path)
+        Utils.check_error(self, "TooManyArguments", error)
+
+    def test_auction_subscribe_newHeads_success(self):
+        method = f"{self.ns}_subscribe"
+        result, error = Utils.call_ws(self.endpoint, method, [
+                                      "newHeads"], self.log_path)
+        self.assertIsNone(error)
+        self.assertIsNotNone(result)
+
+    def test_auction_subscribe_logs_error_no_params(self):
+        method = f"{self.ns}_subscribe"
+        _, error = Utils.call_ws(self.endpoint, method, [
+                                 "logs"], self.log_path)
+        Utils.check_error(self, "arg1NoParams", error)
+
+    def test_auction_subscribe_logs_error_invalid_filter_criteria(self):
+        method = f"{self.ns}_subscribe"
+        filter_criteria = {
+            "fromBlock": "invalid",
+            "toBlock": "invalid"
+        }
+        _, error = Utils.call_ws(self.endpoint, method, [
+                                 "logs", filter_criteria], self.log_path)
+        Utils.check_error(self, "arg1HexWithoutPrefix", error)
+
+    def test_auction_subscribe_logs_error_invalid_address(self):
+        method = f"{self.ns}_subscribe"
+        filter_criteria = {
+            "fromBlock": "latest",
+            "toBlock": "latest",
+            "address": "0xinvalid"
+        }
+        _, error = Utils.call_ws(self.endpoint, method, [
+                                 "logs", filter_criteria], self.log_path)
+        Utils.check_error(self, "arg1InvalidAddress", error)
+
+    def test_auction_subscribe_logs_error_invalid_topics_format(self):
+        method = f"{self.ns}_subscribe"
+        filter_criteria = {
+            "fromBlock": "latest",
+            "toBlock": "latest",
+            "address": "0x0000000000000000000000000000000000000000",
+            "topics": ["invalid_topic_format"]  # Invalid topic format
+        }
+        _, error = Utils.call_ws(self.endpoint, method, [
+                                 "logs", filter_criteria], self.log_path)
+        Utils.check_error(self, "arg1HexWithoutPrefix", error)
+
+    def test_auction_subscribe_logs_success_basic(self):
+        method = f"{self.ns}_subscribe"
+        filter_criteria = {
+            "fromBlock": "latest",
+            "toBlock": "latest",
+            "address": "0x0000000000000000000000000000000000000000"
+        }
+        result, error = Utils.call_ws(self.endpoint, method, [
+                                      "logs", filter_criteria], self.log_path)
+        self.assertIsNone(error)
+        self.assertIsNotNone(result)
+
+    def test_auction_subscribe_logs_success_with_topics(self):
+        method = f"{self.ns}_subscribe"
+        filter_criteria = {
+            "fromBlock": "latest",
+            "toBlock": "latest",
+            "address": "0x0000000000000000000000000000000000000000",
+            "topics": ["0x0000000000000000000000000000000000000000000000000000000000000000"]
+        }
+        result, error = Utils.call_ws(self.endpoint, method, [
+                                      "logs", filter_criteria], self.log_path)
+        self.assertIsNone(error)
+        self.assertIsNotNone(result)
+
+    @staticmethod
+    def suite():
+        suite = unittest.TestSuite()
+
+        # newPendingTransactions tests
+        suite.addTest(TestKaiaNamespaceAuctionWS(
+            "test_auction_subscribe_newPendingTransactions_error_invalid_param_type"))
+        suite.addTest(TestKaiaNamespaceAuctionWS(
+            "test_auction_subscribe_newPendingTransactions_success_no_param"))
+        suite.addTest(TestKaiaNamespaceAuctionWS(
+            "test_auction_subscribe_newPendingTransactions_success_with_full_tx_true"))
+        suite.addTest(TestKaiaNamespaceAuctionWS(
+            "test_auction_subscribe_newPendingTransactions_success_with_full_tx_false"))
+
+        # newHeads tests
+        suite.addTest(TestKaiaNamespaceAuctionWS(
+            "test_auction_subscribe_newHeads_error_with_params"))
+        suite.addTest(TestKaiaNamespaceAuctionWS(
+            "test_auction_subscribe_newHeads_success"))
+
+        # logs tests
+        suite.addTest(TestKaiaNamespaceAuctionWS(
+            "test_auction_subscribe_logs_error_no_params"))
+        suite.addTest(TestKaiaNamespaceAuctionWS(
+            "test_auction_subscribe_logs_error_invalid_filter_criteria"))
+        suite.addTest(TestKaiaNamespaceAuctionWS(
+            "test_auction_subscribe_logs_error_invalid_address"))
+        suite.addTest(TestKaiaNamespaceAuctionWS(
+            "test_auction_subscribe_logs_error_invalid_topics_format"))
+        suite.addTest(TestKaiaNamespaceAuctionWS(
+            "test_auction_subscribe_logs_success_basic"))
+        suite.addTest(TestKaiaNamespaceAuctionWS(
+            "test_auction_subscribe_logs_success_with_topics"))
+
+        return suite

--- a/kaia/auction/kaia_auction_ws.py
+++ b/kaia/auction/kaia_auction_ws.py
@@ -1,6 +1,7 @@
 import unittest
 
 from utils import Utils
+import json
 
 # test_data_set is injected by rpc-tester/main.py
 global test_data_set
@@ -23,24 +24,129 @@ class TestKaiaNamespaceAuctionWS(unittest.TestCase):
 
     def test_auction_subscribe_newPendingTransactions_success_no_param(self):
         method = f"{self.ns}_subscribe"
-        result, error = Utils.call_ws(self.endpoint, method, [
+        result, error, ws = Utils.open_ws(self.endpoint, method, [
                                       "newPendingTransactions"], self.log_path)
-        self.assertIsNone(error)
-        self.assertIsNotNone(result)
+        try:
+            self.assertIsNone(error)
+            self.assertIsNotNone(result)
+            self.assertTrue(result.startswith("0x"))
+
+            Utils.waiting_count("Waiting for", 2, "seconds for pending transaction data.")
+
+            ws.settimeout(3)
+            try:
+                response = ws.recv()
+                self.assertIsNotNone(response)
+            except Exception as e:
+                self.assertTrue(result.startswith("0x"))
+                self.assertGreater(len(result), 2)
+                return
+
+            response_json = json.loads(response)
+            self.assertIn("jsonrpc", response_json)
+            self.assertIn("method", response_json)
+            self.assertIn("params", response_json)
+            self.assertEqual(response_json.get("jsonrpc"), "2.0")
+            self.assertEqual(response_json.get("method"), "auction_subscription")
+
+            params = response_json.get("params")
+            self.assertIsNotNone(params)
+            self.assertIn("subscription", params)
+            self.assertIn("result", params)
+            self.assertEqual(params.get("subscription"), result)
+
+            tx_hash = params.get("result")
+            self.assertIsNotNone(tx_hash)
+
+        finally:
+            ws.close()
 
     def test_auction_subscribe_newPendingTransactions_success_with_full_tx_true(self):
         method = f"{self.ns}_subscribe"
-        result, error = Utils.call_ws(self.endpoint, method, [
+        result, error, ws = Utils.open_ws(self.endpoint, method, [
                                       "newPendingTransactions", True], self.log_path)
-        self.assertIsNone(error)
-        self.assertIsNotNone(result)
+        try:
+            self.assertIsNone(error)
+            self.assertIsNotNone(result)
+            self.assertTrue(result.startswith("0x"))
+
+            Utils.waiting_count("Waiting for", 2, "seconds for pending transaction data.")
+
+            ws.settimeout(3)
+            try:
+                response = ws.recv()
+                self.assertIsNotNone(response)
+            except Exception as e:
+                self.assertTrue(result.startswith("0x"))
+                self.assertGreater(len(result), 2)
+                return
+
+            response_json = json.loads(response)
+            self.assertIn("jsonrpc", response_json)
+            self.assertIn("method", response_json)
+            self.assertIn("params", response_json)
+            self.assertEqual(response_json.get("jsonrpc"), "2.0")
+            self.assertEqual(response_json.get("method"), "auction_subscription")
+
+            params = response_json.get("params")
+            self.assertIsNotNone(params)
+            self.assertIn("subscription", params)
+            self.assertIn("result", params)
+            self.assertEqual(params.get("subscription"), result)
+
+            result_data = params.get("result")
+            self.assertIsNotNone(result_data)
+            self.assertIsInstance(result_data, dict)
+
+            required_fields = ["hash", "from", "to", "value", "gas", "gasPrice", "nonce"]
+            for field in required_fields:
+                if field in result_data:
+                    self.assertIsNotNone(result_data[field])
+
+            if "time" in result_data:
+                self.assertIsNotNone(result_data["time"])
+
+        finally:
+            ws.close()
 
     def test_auction_subscribe_newPendingTransactions_success_with_full_tx_false(self):
         method = f"{self.ns}_subscribe"
-        result, error = Utils.call_ws(self.endpoint, method, [
+        result, error, ws = Utils.open_ws(self.endpoint, method, [
                                       "newPendingTransactions", False], self.log_path)
-        self.assertIsNone(error)
-        self.assertIsNotNone(result)
+        try:
+            self.assertIsNone(error)
+            self.assertIsNotNone(result)
+            self.assertTrue(result.startswith("0x"))
+
+            Utils.waiting_count("Waiting for", 2, "seconds for pending transaction data.")
+
+            ws.settimeout(3)
+            try:
+                response = ws.recv()
+                self.assertIsNotNone(response)
+            except Exception as e:
+                self.assertTrue(result.startswith("0x"))
+                self.assertGreater(len(result), 2)
+                return
+
+            response_json = json.loads(response)
+            self.assertIn("jsonrpc", response_json)
+            self.assertIn("method", response_json)
+            self.assertIn("params", response_json)
+            self.assertEqual(response_json.get("jsonrpc"), "2.0")
+            self.assertEqual(response_json.get("method"), "auction_subscription")
+
+            params = response_json.get("params")
+            self.assertIsNotNone(params)
+            self.assertIn("subscription", params)
+            self.assertIn("result", params)
+            self.assertEqual(params.get("subscription"), result)
+
+            tx_hash = params.get("result")
+            self.assertIsNotNone(tx_hash)
+
+        finally:
+            ws.close()
 
     def test_auction_subscribe_newHeads_error_with_params(self):
         method = f"{self.ns}_subscribe"
@@ -50,10 +156,58 @@ class TestKaiaNamespaceAuctionWS(unittest.TestCase):
 
     def test_auction_subscribe_newHeads_success(self):
         method = f"{self.ns}_subscribe"
-        result, error = Utils.call_ws(self.endpoint, method, [
+        result, error, ws = Utils.open_ws(self.endpoint, method, [
                                       "newHeads"], self.log_path)
-        self.assertIsNone(error)
-        self.assertIsNotNone(result)
+        try:
+            self.assertIsNone(error)
+            self.assertIsNotNone(result)
+            self.assertTrue(result.startswith("0x"))
+
+            Utils.waiting_count("Waiting for", 2, "seconds for new block data.")
+
+            ws.settimeout(3)
+            try:
+                response = ws.recv()
+                self.assertIsNotNone(response)
+            except Exception as e:
+                self.assertTrue(result.startswith("0x"))
+                self.assertGreater(len(result), 2)
+                return
+
+            response_json = json.loads(response)
+            self.assertIn("jsonrpc", response_json)
+            self.assertIn("method", response_json)
+            self.assertIn("params", response_json)
+            self.assertEqual(response_json.get("jsonrpc"), "2.0")
+            self.assertEqual(response_json.get("method"), "auction_subscription")
+
+            params = response_json.get("params")
+            self.assertIsNotNone(params)
+            self.assertIn("subscription", params)
+            self.assertIn("result", params)
+            self.assertEqual(params.get("subscription"), result)
+
+            block_data = params.get("result")
+            self.assertIsNotNone(block_data)
+            self.assertIsInstance(block_data, dict)
+
+            required_fields = [
+                "number", "hash", "parentHash", "timestamp", "gasUsed",
+                "transactionsRoot", "receiptsRoot", "stateRoot", "logsBloom",
+                "extraData", "governanceData", "voteData", "reward", "blockScore"
+            ]
+
+            for field in required_fields:
+                self.assertIn(field, block_data, f"Missing required field: {field}")
+                self.assertIsNotNone(block_data[field])
+
+            optional_fields = ["baseFeePerGas", "size", "mixhash", "randomReveal", "timestampFoS"]
+            for field in optional_fields:
+                if field in block_data:
+                    self.assertIsNotNone(block_data[field])
+
+        finally:
+            ws.close()
 
     def test_auction_subscribe_logs_error_no_params(self):
         method = f"{self.ns}_subscribe"
@@ -101,10 +255,53 @@ class TestKaiaNamespaceAuctionWS(unittest.TestCase):
             "toBlock": "latest",
             "address": "0x0000000000000000000000000000000000000000"
         }
-        result, error = Utils.call_ws(self.endpoint, method, [
-                                      "logs", filter_criteria], self.log_path)
-        self.assertIsNone(error)
-        self.assertIsNotNone(result)
+
+        result, error, ws = Utils.open_ws(self.endpoint, method, ["logs", filter_criteria], self.log_path)
+        try:
+            self.assertIsNone(error)
+            self.assertIsNotNone(result)
+            self.assertTrue(result.startswith("0x"))
+
+            Utils.waiting_count("Waiting for", 2, "seconds for log data.")
+            ws.settimeout(3)
+
+            try:
+                response = ws.recv()
+                self.assertIsNotNone(response)
+            except Exception as e:
+                self.assertTrue(result.startswith("0x"))
+                self.assertGreater(len(result), 2)
+                return
+
+            response_json = json.loads(response)
+            self.assertIn("jsonrpc", response_json)
+            self.assertIn("method", response_json)
+            self.assertIn("params", response_json)
+            self.assertEqual(response_json.get("jsonrpc"), "2.0")
+            self.assertEqual(response_json.get("method"), "auction_subscription")
+
+            params = response_json.get("params")
+            self.assertIsNotNone(params)
+            self.assertIn("subscription", params)
+            self.assertIn("result", params)
+            self.assertEqual(params.get("subscription"), result)
+
+            log_result = params.get("result")
+            self.assertIsNotNone(log_result)
+            self.assertIsInstance(log_result, dict)
+
+            required_fields = ["address", "topics", "data", "blockNumber", "transactionHash"]
+            for field in required_fields:
+                self.assertIn(field, log_result, f"Missing required field: {field}")
+                self.assertIsNotNone(log_result[field])
+
+            optional_fields = ["transactionIndex", "blockHash", "logIndex", "removed"]
+            for field in optional_fields:
+                if field in log_result:
+                    self.assertIsNotNone(log_result[field])
+
+        finally:
+            ws.close()
 
     def test_auction_subscribe_logs_success_with_topics(self):
         method = f"{self.ns}_subscribe"
@@ -114,10 +311,53 @@ class TestKaiaNamespaceAuctionWS(unittest.TestCase):
             "address": "0x0000000000000000000000000000000000000000",
             "topics": ["0x0000000000000000000000000000000000000000000000000000000000000000"]
         }
-        result, error = Utils.call_ws(self.endpoint, method, [
-                                      "logs", filter_criteria], self.log_path)
-        self.assertIsNone(error)
-        self.assertIsNotNone(result)
+
+        result, error, ws = Utils.open_ws(self.endpoint, method, ["logs", filter_criteria], self.log_path)
+        try:
+            self.assertIsNone(error)
+            self.assertIsNotNone(result)
+            self.assertTrue(result.startswith("0x"))
+
+            Utils.waiting_count("Waiting for", 2, "seconds for log data.")
+            ws.settimeout(3)
+
+            try:
+                response = ws.recv()
+                self.assertIsNotNone(response)
+            except Exception as e:
+                self.assertTrue(result.startswith("0x"))
+                self.assertGreater(len(result), 2)
+                return
+
+            response_json = json.loads(response)
+            self.assertIn("jsonrpc", response_json)
+            self.assertIn("method", response_json)
+            self.assertIn("params", response_json)
+            self.assertEqual(response_json.get("jsonrpc"), "2.0")
+            self.assertEqual(response_json.get("method"), "auction_subscription")
+
+            params = response_json.get("params")
+            self.assertIsNotNone(params)
+            self.assertIn("subscription", params)
+            self.assertIn("result", params)
+            self.assertEqual(params.get("subscription"), result)
+
+            log_result = params.get("result")
+            self.assertIsNotNone(log_result)
+            self.assertIsInstance(log_result, dict)
+
+            required_fields = ["address", "topics", "data", "blockNumber", "transactionHash"]
+            for field in required_fields:
+                self.assertIn(field, log_result, f"Missing required field: {field}")
+                self.assertIsNotNone(log_result[field])
+
+            optional_fields = ["transactionIndex", "blockHash", "logIndex", "removed"]
+            for field in optional_fields:
+                if field in log_result:
+                    self.assertIsNotNone(log_result[field])
+
+        finally:
+            ws.close()
 
     @staticmethod
     def suite():

--- a/main.py
+++ b/main.py
@@ -83,7 +83,10 @@ from kaia.gas import kaia_gas_rpc
 from kaia.gas import kaia_gas_ws
 from kaia.gas.kaia_gas_rpc import TestKaiaNamespaceGasRPC
 from kaia.gas.kaia_gas_ws import TestKaiaNamespaceGasWS
-
+from kaia.auction import kaia_auction_rpc
+from kaia.auction import kaia_auction_ws
+from kaia.auction.kaia_auction_rpc import TestKaiaNamespaceAuctionRPC
+from kaia.auction.kaia_auction_ws import TestKaiaNamespaceAuctionWS
 
 test_data_set = None
 config = None
@@ -760,6 +763,8 @@ def inject_test_data_to_testcases():
     eth_gas_ws.test_data_set = test_data_set
     kaia_gas_rpc.test_data_set = test_data_set
     kaia_gas_ws.test_data_set = test_data_set
+    kaia_auction_rpc.test_data_set = test_data_set
+    kaia_auction_ws.test_data_set = test_data_set
 
 
 def load_test_suites():
@@ -771,7 +776,7 @@ def load_test_suites():
     rpc_test_suites = list()
     ws_test_suites = list()
 
-    namespaces = config.get("namespaces", "admin,debug,eth,governance,kaia,net,personal,txpool")
+    namespaces = config.get("namespaces", "admin,debug,eth,governance,kaia,net,personal,txpool,auction")
     namespaces = namespaces.split(",")
 
     if "admin" in namespaces:
@@ -825,6 +830,10 @@ def load_test_suites():
         ws_test_suites.append(TestEthNamespaceFilterWS.suite())
         rpc_test_suites.append(TestEthNamespaceGasRPC.suite())
         ws_test_suites.append(TestEthNamespaceGasWS.suite())
+
+    if "auction" in namespaces:
+        rpc_test_suites.append(TestKaiaNamespaceAuctionRPC.suite())
+        ws_test_suites.append(TestKaiaNamespaceAuctionWS.suite())
 
 
 def initialize():

--- a/script/cn/conf/kcnd.conf
+++ b/script/cn/conf/kcnd.conf
@@ -23,7 +23,7 @@ TXPOOL_LIFE_TIME="5m"
 
 # rpc options setting
 RPC_ENABLE=1 # if this is set, the following options will be used
-RPC_API="eth,admin,debug,kaia,miner,net,personal,rpc,txpool,web3" # available apis: admin,debug,kaia,miner,net,personal,rpc,txpool,web3
+RPC_API="eth,admin,debug,kaia,miner,net,personal,rpc,txpool,web3,auction" # available apis: admin,debug,kaia,miner,net,personal,rpc,txpool,web3,auction
 RPC_PORT=8551
 RPC_ADDR="0.0.0.0"
 RPC_CORSDOMAIN="*"
@@ -31,7 +31,7 @@ RPC_VHOSTS="*"
 
 # ws options setting
 WS_ENABLE=1 # if this is set, the following options will be used
-WS_API="eth,admin,debug,kaia,miner,net,personal,rpc,txpool,web3" # available apis: admin,debug,kaia,miner,net,personal,rpc,txpool,web3
+WS_API="eth,admin,debug,kaia,miner,net,personal,rpc,txpool,web3,auction" # available apis: admin,debug,kaia,miner,net,personal,rpc,txpool,web3,auction
 WS_ADDR="0.0.0.0"
 WS_PORT=8552
 WS_ORIGINS="*"
@@ -52,3 +52,7 @@ BOOTNODES=""
 ADDITIONAL="--gcmode archive --unlock 0 --password cn/conf/pwd.txt --txpool.allow-local-anchortx"
 DATA_DIR=cn/data
 LOG_DIR=$DATA_DIR/kcn/logs
+
+# Auction settings
+AUCTION_DISABLE=0
+AUCTION_MAX_BID_POOL_SIZE=1000


### PR DESCRIPTION
## Overview
Adds test coverage for the Auction API functionality implemented in https://github.com/kaiachain/kaia/pull/466

- Tested on CN with v2.1.0-rc.2: https://github.com/kaiachain/kaia/releases/tag/v2.1.0-rc.2

## Test Coverage

### RPC Tests (`kaia_auction_rpc.py`)
- **`auction_submitBid`**: 8 test cases focusing on input validation (parameter format, address validation, field types)
  - **Current Focus**: Non-business logic validation that works
- **`auction_call`**: 18 test cases covering contract call functionality

### WebSocket Tests (`kaia_auction_ws.py`)
- **`newPendingTransactions`**: 4 test cases (1 error + 3 success)
- **`newHeads`**: 2 test cases (1 error + 1 success)
- **`logs`**: 6 test cases (4 error + 2 success)
