### PR TITLE
test(utils,ws): add Kaia/Eth newHeads verifiers and update WS tests

### DIFF
--- a/eth/filter/eth_filter_ws.py
+++ b/eth/filter/eth_filter_ws.py
@@ -357,7 +357,7 @@ class TestEthNamespaceFilterWS(unittest.TestCase):
             Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
 
             response = ws.recv()
-            Utils.check_response_type_newHeads_subscription(self, response)
+            Utils.check_response_type_newHeads_subscription_eth(self, response)
 
         finally:
             ws.close()

--- a/kaia/auction/kaia_auction_ws.py
+++ b/kaia/auction/kaia_auction_ws.py
@@ -174,37 +174,8 @@ class TestKaiaNamespaceAuctionWS(unittest.TestCase):
                 self.assertGreater(len(result), 2)
                 return
 
-            response_json = json.loads(response)
-            self.assertIn("jsonrpc", response_json)
-            self.assertIn("method", response_json)
-            self.assertIn("params", response_json)
-            self.assertEqual(response_json.get("jsonrpc"), "2.0")
-            self.assertEqual(response_json.get("method"), "auction_subscription")
 
-            params = response_json.get("params")
-            self.assertIsNotNone(params)
-            self.assertIn("subscription", params)
-            self.assertIn("result", params)
-            self.assertEqual(params.get("subscription"), result)
-
-            block_data = params.get("result")
-            self.assertIsNotNone(block_data)
-            self.assertIsInstance(block_data, dict)
-
-            required_fields = [
-                "number", "hash", "parentHash", "timestamp", "gasUsed",
-                "transactionsRoot", "receiptsRoot", "stateRoot", "logsBloom",
-                "extraData", "governanceData", "voteData", "reward", "blockScore"
-            ]
-
-            for field in required_fields:
-                self.assertIn(field, block_data, f"Missing required field: {field}")
-                self.assertIsNotNone(block_data[field])
-
-            optional_fields = ["baseFeePerGas", "size", "mixhash", "randomReveal", "timestampFoS"]
-            for field in optional_fields:
-                if field in block_data:
-                    self.assertIsNotNone(block_data[field])
+            Utils.check_response_type_newHeads_subscription_kaia(self, response)
 
         finally:
             ws.close()

--- a/kaia/filter/kaia_filter_ws.py
+++ b/kaia/filter/kaia_filter_ws.py
@@ -359,7 +359,7 @@ class TestKaiaNamespaceFilterWS(unittest.TestCase):
             Utils.waiting_count("Waiting for", 5, "seconds until writing a block.")
 
             response = ws.recv()
-            Utils.check_response_type_newHeads_subscription(self, response)
+            Utils.check_response_type_newHeads_subscription_kaia(self, response)
 
         finally:
             ws.close()

--- a/utils.py
+++ b/utils.py
@@ -400,14 +400,94 @@ class Utils(unittest.TestCase):
         target_instance.assertIn(expected_error_message, error.get("message"), error)
 
     @staticmethod
-    def check_response_type_newHeads_subscription(target_instance, response):
+    def check_response_type_newHeads_subscription_kaia(target_instance, response):
         """
-        Check whether given response is expected response or not.
-        target_instance must inherit unittest.TestCase class.
+        Verify newHeads subscription payload for Kaia header format (RPCMarshalHeader)
+        returned by kaia_subscribe and auction_subscribe.
         """
         response_json = json.loads(response)
-        params = response_json.get('params')
+        params = response_json.get("params")
         target_instance.assertIsNotNone(params)
-        target_instance.assertIsNotNone(params.get('subscription'))
-        result = params.get('result')
-        target_instance.assertIsNotNone(result.get('number'))
+        target_instance.assertIn("subscription", params)
+        target_instance.assertIn("result", params)
+
+        header = params.get("result")
+        target_instance.assertIsInstance(header, dict)
+
+        required_fields = [
+            "number",
+            "hash",
+            "parentHash",
+            "timestamp",
+            "timestampFoS",
+            "gasUsed",
+            "transactionsRoot",
+            "receiptsRoot",
+            "stateRoot",
+            "logsBloom",
+            "extraData",
+            "governanceData",
+            "voteData",
+            "reward",
+            "blockScore",
+        ]
+        for field in required_fields:
+            target_instance.assertIn(field, header, f"Missing required field: {field}")
+            target_instance.assertIsNotNone(header.get(field))
+
+        # Kaia header extras from RPCMarshalHeader; treat as optional
+        optional_fields = [
+            "baseFeePerGas",
+            "randomReveal",
+            "mixhash",
+        ]
+        for field in optional_fields:
+            if field in header:
+                target_instance.assertIsNotNone(header.get(field))
+
+    @staticmethod
+    def check_response_type_newHeads_subscription_eth(target_instance, response):
+        """
+        Verify newHeads subscription payload for Eth-compatible header format
+        (RpcMarshalEthHeader) returned by eth_subscribe.
+        """
+        response_json = json.loads(response)
+        params = response_json.get("params")
+        target_instance.assertIsNotNone(params)
+        target_instance.assertIn("subscription", params)
+        target_instance.assertIn("result", params)
+
+        header = params.get("result")
+        target_instance.assertIsInstance(header, dict)
+
+        required_fields = [
+            "number",
+            "hash",
+            "parentHash",
+            "nonce",
+            "mixHash",
+            "sha3Uncles",
+            "logsBloom",
+            "stateRoot",
+            "miner",
+            "difficulty",
+            "extraData",
+            "size",
+            "gasLimit",
+            "gasUsed",
+            "timestamp",
+            "transactionsRoot",
+            "receiptsRoot",
+        ]
+        for field in required_fields:
+            target_instance.assertIn(field, header, f"Missing required field: {field}")
+            target_instance.assertIsNotNone(header.get(field))
+
+        # Eth-compatible extras expected from RpcMarshalEthHeader; treat as optional
+        optional_fields = [
+            "baseFeePerGas",
+            "randomReveal",
+        ]
+        for field in optional_fields:
+            if field in header:
+                target_instance.assertIsNotNone(header.get(field))


### PR DESCRIPTION
## Overview

- Adds explicit verifiers for newHeads subscription payloads and refactors WS tests to use them:
  - `Utils.check_response_type_newHeads_subscription_kaia` (used by `kaia_subscribe` and `auction_subscribe`)
  - `Utils.check_response_type_newHeads_subscription_eth` (used by `eth_subscribe`)
- Removes the deprecated generic newHeads verifier
- Aligned required/optional fields to match each marshaller (Kaia: `RPCMarshalHeader`, Eth: `RpcMarshalEthHeader`).

Related to https://github.com/kaiachain/kaia-rpc-tester/pull/15#discussion_r2258613699