### PR TITLE
patch _count_relevant_tb_levels to HtmlTestRunner only if missing

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,10 @@ import json
 import argparse
 import types
 from functools import wraps
+# Fix for HtmlTestRunner compatibility
+import HtmlTestRunner.result as R
+if not hasattr(R.HtmlTestResult, "_count_relevant_tb_levels"):
+    R.HtmlTestResult._count_relevant_tb_levels = lambda self, tb: None
 from HtmlTestRunner import HTMLTestRunner
 from utils import Utils
 from common import personal as personal_common


### PR DESCRIPTION
This PR fixes next error by patching non-existing method for `_count_relevant_tb_levels` only if missing to avoid overriding existing implementations in HtmlTestRunner.
```
 test_auction_submitBid_error_no_param (kaia.auction.kaia_auction_rpc.TestKaiaNamespaceAuctionRPC) ... Traceback (most recent call last):
  File "/root/go/src/github.com/kaiachain/kaia/kaia-rpc-tester/main.py", line 872, in <module>
    result = runner.run(all_test_suite)
  File "/root/go/src/github.com/kaiachain/kaia/kaia-rpc-tester/venv/lib/python3.10/site-packages/HtmlTestRunner/runner.py", line 72, in run
    test(result)
  File "/usr/lib/python3.10/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python3.10/unittest/suite.py", line 122, in run
    test(result)
  File "/usr/lib/python3.10/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python3.10/unittest/suite.py", line 122, in run
    test(result)
  File "/usr/lib/python3.10/unittest/case.py", line 650, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python3.10/unittest/case.py", line 599, in run
    self._feedErrorsToResult(result, outcome.errors)
  File "/usr/lib/python3.10/unittest/case.py", line 516, in _feedErrorsToResult
    result.addFailure(test, exc_info)
  File "/usr/lib/python3.10/unittest/result.py", line 17, in inner
    return method(self, *args, **kw)
  File "/root/go/src/github.com/kaiachain/kaia/kaia-rpc-tester/venv/lib/python3.10/site-packages/HtmlTestRunner/result.py", line 205, in addFailure
    testinfo = self.infoclass(self, test, self.infoclass.FAILURE, err)
  File "/root/go/src/github.com/kaiachain/kaia/kaia-rpc-tester/venv/lib/python3.10/site-packages/HtmlTestRunner/result.py", line 90, in __init__
    else self.test_result._exc_info_to_string(
  File "/root/go/src/github.com/kaiachain/kaia/kaia-rpc-tester/venv/lib/python3.10/site-packages/HtmlTestRunner/result.py", line 425, in _exc_info_to_string
    length = self._count_relevant_tb_levels(tb)
AttributeError: 'HtmlTestResult' object has no attribute '_count_relevant_tb_levels'. Did you mean: '_is_relevant_tb_level'?

```
