### PR TITLE
fix: derive runtime APIs from node/config

### DIFF
--- a/admin/admin_ws.py
+++ b/admin/admin_ws.py
@@ -17,6 +17,8 @@ class TestAdminNamespaceWS(unittest.TestCase):
     ns = "admin"
     waiting_count = 2
     current_dt = None
+    rpc_runtime_apis_csv = None
+    ws_runtime_apis_csv = None
 
     def test_admin_addPeer_error_no_param(self):
         method = f"{self.ns}_addPeer"
@@ -176,17 +178,27 @@ class TestAdminNamespaceWS(unittest.TestCase):
         self.assertIsNone(error)
 
     def create_params_for_starting_rpc(self):
-        host = "0.0.0.0"
+        host = Utils.parse_conf_value("RPC_ADDR") or "0.0.0.0"
         port = int(self.rpc_port)
-        cors = "*"
-        apis = "admin,eth,kaia,net,personal,debug,web3,txpool"
+        cors = Utils.parse_conf_value("RPC_CORSDOMAIN") or "*"
+        # Use cached runtime APIs if available (RPC only)
+        if TestAdminNamespaceWS.rpc_runtime_apis_csv:
+            apis = TestAdminNamespaceWS.rpc_runtime_apis_csv
+        else:
+            apis = Utils.snapshot_runtime_apis(self.endpoint, self.log_path, transport="rpc", port=int(self.rpc_port))
+            TestAdminNamespaceWS.rpc_runtime_apis_csv = apis
         return [host, port, cors, apis]
 
     def create_params_for_starting_ws(self):
-        host = "0.0.0.0"
+        host = Utils.parse_conf_value("WS_ADDR") or "0.0.0.0"
         port = int(self.ws_port)
-        cors = "*"
-        apis = "admin,eth,kaia,net,personal,debug,web3,txpool"
+        cors = Utils.parse_conf_value("WS_ORIGINS") or "*"
+        # Use cached runtime APIs if available (WS only)
+        if TestAdminNamespaceWS.ws_runtime_apis_csv:
+            apis = TestAdminNamespaceWS.ws_runtime_apis_csv
+        else:
+            apis = Utils.snapshot_runtime_apis(self.endpoint, self.log_path, transport="ws", port=int(self.ws_port))
+            TestAdminNamespaceWS.ws_runtime_apis_csv = apis
         return [host, port, cors, apis]
 
     def test_admin_startRPC_error_wrong_type_param1_using_ws(self):

--- a/script/cn/conf/kcnd.conf
+++ b/script/cn/conf/kcnd.conf
@@ -52,7 +52,3 @@ BOOTNODES=""
 ADDITIONAL="--gcmode archive --unlock 0 --password cn/conf/pwd.txt --txpool.allow-local-anchortx"
 DATA_DIR=cn/data
 LOG_DIR=$DATA_DIR/kcn/logs
-
-# Auction settings
-AUCTION_DISABLE=0
-AUCTION_MAX_BID_POOL_SIZE=1000

--- a/utils.py
+++ b/utils.py
@@ -491,3 +491,53 @@ class Utils(unittest.TestCase):
         for field in optional_fields:
             if field in header:
                 target_instance.assertIsNotNone(header.get(field))
+
+    @staticmethod
+    def parse_conf_value(key: str, conf_path: str = "") -> str:
+        """
+        Read a value for the given key from kcnd.conf.
+        Falls back to the default test path if conf_path is not provided.
+        Returns an empty string if the key/path is not found.
+        """
+        try:
+            path = (
+                conf_path
+                if conf_path
+                else f"{PROJECT_ROOT_DIR}/script/cn/conf/kcnd.conf"
+            )
+            text = pathlib.Path(path).read_text()
+            m = re.search(rf'^{key}="?([^"\n#]+)"?', text, flags=re.M)
+            return "" if not m else m.group(1).strip()
+        except Exception:
+            return ""
+
+    @staticmethod
+    def snapshot_runtime_apis(
+        endpoint: str,
+        log_path: str,
+        transport: str,
+        port: int,
+        ) -> str:
+        """
+        Fetch current runtime modules via rpc_modules for the given transport and port.
+        - transport="rpc": query HTTP RPC only
+        - transport="ws": query WebSocket only
+        Returns CSV string of module names or empty string on failure.
+        """
+        t = transport.lower()
+        if t not in ("rpc", "ws"):
+            raise ValueError("transport must be 'rpc' or 'ws'")
+
+        call = Utils.call_rpc if t == "rpc" else Utils.call_ws
+        conf_key = "RPC_API" if t == "rpc" else "WS_API"
+
+        try:
+            res, err = call(endpoint, "rpc_modules", [], log_path, port=port)
+            if err is None and isinstance(res, dict) and len(res) > 0:
+                return ",".join(sorted(res.keys()))
+            if err is not None:
+                return Utils.parse_conf_value(conf_key) or ""
+        except Exception:
+            return Utils.parse_conf_value(conf_key) or ""
+
+        return ""


### PR DESCRIPTION
## Overview
- Auction tests were failing in CI ([CircleCI job](https://app.circleci.com/pipelines/github/kaiachain/kaia/3561/workflows/2131119e-1c0e-427b-b158-05f2f50bc491/jobs/19859))
- Because **admin_startRPC/WS** was started with hardcoded APIs, which omitted `auction`. As a result, Auction API wasn’t enabled during tests.

## Changes
### utils:
- Add `snapshot_runtime_apis(endpoint, log_path, transport, port)` to read runtime namespaces via `rpc_modules`, with fallback to `kcnd.conf` (`RPC_API`/`WS_API`) when errors occur.
- Add `parse_conf_value` to read `RPC_ADDR`/`RPC_CORSDOMAIN`/`WS_ADDR`/`WS_ORIGINS` and other keys from `kcnd.conf`.

### admin (`admin_rpc.py`, `admin_ws.py`):
- Build start parameters from `snapshot_runtime_apis` and conf values instead of hardcoded strings.
- Maintain per-transport caches (RPC/WS) for runtime APIs.